### PR TITLE
[fe] Dropdown 컴포넌트 UI 구현

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,7 @@
-import { ThemeProvider } from "styled-components";
-import { designSystem } from "./constants/designSystem";
-import DropdownIndicator from "./components/dropdown/DropdownIndicator";
 import { useState } from "react";
-import DropdownPanel from "./components/dropdown/DropdownPanel";
+import { ThemeProvider } from "styled-components";
+import DropdownContainer from "./components/dropdown/DropdownContainer";
+import { designSystem } from "./constants/designSystem";
 
 export default function App() {
   const [themeMode, setThemeMode] = useState<"light" | "dark">("light");
@@ -10,9 +9,7 @@ export default function App() {
   return (
     <ThemeProvider theme={designSystem[themeMode]}>
       <div>hello world</div>
-      <DropdownIndicator>Button</DropdownIndicator>
-      <DropdownIndicator disabled>Button</DropdownIndicator>
-      <DropdownPanel />
+      <DropdownContainer />
     </ThemeProvider>
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import { ThemeProvider } from "styled-components";
-import DropdownContainer from "./components/dropdown/DropdownContainer";
-import Button from "./components/Button";
+import { Button } from "./components/Button";
 import { TextInput } from "./components/TextInput";
+import { DropdownContainer } from "./components/dropdown/DropdownContainer";
 import { designSystem } from "./constants/designSystem";
 
 export default function App() {
@@ -14,7 +14,7 @@ export default function App() {
 
   return (
     <ThemeProvider theme={designSystem[themeMode]}>
-      <DropdownContainer />
+      <DropdownTest />
       <TextInputTest />
       <ButtonTest onClick={onClick} />
     </ThemeProvider>
@@ -26,8 +26,8 @@ function ButtonTest({ onClick }: { onClick: () => void }) {
     <div>
       <Button
         icon="alertCircle"
-        size="medium"
-        buttonType="container"
+        size="L"
+        buttonType="Container"
         selected
         onClick={onClick}
       >
@@ -35,8 +35,8 @@ function ButtonTest({ onClick }: { onClick: () => void }) {
       </Button>
       <Button
         icon="alertCircle"
-        size="medium"
-        buttonType="outline"
+        size="M"
+        buttonType="Outline"
         selected
         onClick={onClick}
       >
@@ -44,8 +44,8 @@ function ButtonTest({ onClick }: { onClick: () => void }) {
       </Button>
       <Button
         icon="alertCircle"
-        size="medium"
-        buttonType="ghost"
+        size="S"
+        buttonType="Ghost"
         selected
         onClick={onClick}
       >
@@ -83,4 +83,48 @@ function TextInputTest() {
       />
     </div>
   );
+}
+
+function DropdownTest() {
+  const options = [
+    {
+      name: "옵션1",
+      profile: "",
+      onClick: () => {
+        console.log("옵션1 선택");
+      },
+    },
+    {
+      name: "옵션2",
+      profile: "",
+      onClick: () => {
+        console.log("옵션2 선택");
+      },
+    },
+    {
+      name: "옵션3",
+      profile: "",
+      onClick: () => {
+        console.log("옵션3 선택");
+      },
+    },
+    {
+      name: "옵션4",
+      profile: "",
+      onClick: () => {
+        console.log("옵션4 선택");
+      },
+    },
+    {
+      name: "옵션5",
+      profile: "",
+      onClick: () => {
+        console.log("옵션5 선택");
+      },
+    },
+  ];
+  return (<>
+    <DropdownContainer name="필터" options={options} alignment="Left" />
+    <DropdownContainer name="필터" options={options} alignment="Right" />
+  </>);
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { ThemeProvider } from "styled-components";
 import { designSystem } from "./constants/designSystem";
 import DropdownIndicator from "./components/dropdown/DropdownIndicator";
 import { useState } from "react";
+import DropdownPanel from "./components/dropdown/DropdownPanel";
 
 export default function App() {
   const [themeMode, setThemeMode] = useState<"light" | "dark">("light");
@@ -11,6 +12,7 @@ export default function App() {
       <div>hello world</div>
       <DropdownIndicator>Button</DropdownIndicator>
       <DropdownIndicator disabled>Button</DropdownIndicator>
+      <DropdownPanel />
     </ThemeProvider>
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,16 @@
 import { ThemeProvider } from "styled-components";
 import { designSystem } from "./constants/designSystem";
+import DropdownIndicator from "./components/dropdown/DropdownIndicator";
+import { useState } from "react";
 
 export default function App() {
+  const [themeMode, setThemeMode] = useState<"light" | "dark">("light");
+
   return (
-    <ThemeProvider theme={designSystem}>
+    <ThemeProvider theme={designSystem[themeMode]}>
       <div>hello world</div>
+      <DropdownIndicator>Button</DropdownIndicator>
+      <DropdownIndicator disabled>Button</DropdownIndicator>
     </ThemeProvider>
   );
 }

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -27,7 +27,12 @@ export default function Button({
   const ButtonComponent = buttonMap[buttonType];
 
   return (
-    <ButtonComponent {...{ $size: size, $flexible: flexible, $selected: selected }} {...props}>
+    <ButtonComponent
+      $size={size}
+      $flexible={flexible}
+      $selected={selected}
+      {...props}
+    >
       <div>
         {icon && <img src={`/src/assets/${icon}.svg`} alt={icon} />}
         <span>{children}</span>
@@ -40,37 +45,61 @@ const StyledButton = styled.button<{
   $size: "small" | "medium" | "large";
   $flexible?: "flexible" | "fixed";
 }>`
-  width: ${({ $size, $flexible }) =>
-    $flexible === "flexible"
-      ? "fit-content"
-      : $size === "large"
-      ? "240px"
-      : $size === "medium"
-      ? "184px"
-      : "128px"};
-  height: ${({ $size }) =>
-    $size === "large" ? "56px" : $size === "medium" ? "48px" : "40px"};
+  width: ${({ $size, $flexible }) => {
+    if ($flexible === "flexible") {
+      return "fit-content";
+    }
+    switch ($size) {
+      case "large":
+        return "240px";
+      case "medium":
+        return "184px";
+      case "small":
+        return "128px";
+      default:
+        return "";
+    }
+  }};
+  height: ${({ $size }) => {
+    switch ($size) {
+      case "large":
+        return "56px";
+      case "medium":
+        return "48px";
+      case "small":
+        return "40px";
+      default:
+        return "";
+    }
+  }};
   padding: ${({ $flexible }) =>
     $flexible === "flexible" ? "0 24px 0 24px" : ""};
-  border-radius: ${({ theme: { radius }, $size }) =>
-    $size === "large" ? radius.large : radius.medium};
-  font: ${({ theme: { font }, $size }) => {
-    const fontSize = $size === "large" ? 20 : $size === "medium" ? 16 : 12;
-
-    return font[`availableMedium${fontSize}`];
+  border-radius: ${({ theme, $size }) =>
+    $size === "large" ? theme.radius.large : theme.radius.medium};
+  font: ${({ theme, $size }) => {
+    switch ($size) {
+      case "large":
+        return theme.font.availableMedium20;
+      case "medium":
+        return theme.font.availableMedium16;
+      case "small":
+        return theme.font.availableMedium12;
+      default:
+        return "";
+    }
   }};
-  opacity: ${({ theme: { opacity } }) => opacity.default};
+  opacity: ${({ theme }) => theme.opacity.default};
 
   &:hover {
-    opacity: ${({ theme: { opacity } }) => opacity.hover};
+    opacity: ${({ theme }) => theme.opacity.hover};
   }
 
   &:active {
-    opacity: ${({ theme: { opacity } }) => opacity.press};
+    opacity: ${({ theme }) => theme.opacity.press};
   }
 
   &:disabled {
-    opacity: ${({ theme: { opacity } }) => opacity.disabled};
+    opacity: ${({ theme }) => theme.opacity.disabled};
   }
 
   div {
@@ -89,36 +118,50 @@ const StyledButton = styled.button<{
 `;
 
 const ConatinerButton = styled(StyledButton)`
-  background-color: ${({ theme: { color } }) => color.brandSurfaceDefault};
-  color: ${({ theme: { color } }) => color.brandTextDefault};
+  background-color: ${({ theme }) => theme.color.brandSurfaceDefault};
+  color: ${({ theme }) => theme.color.brandTextDefault};
 
   img {
-    filter: ${({ theme: { iconFilter } }) => iconFilter.brandTextDefault};
+    filter: ${({ theme }) => theme.iconFilter.brandTextDefault};
   }
 `;
 
 const OutlineButton = styled(StyledButton)`
-  border: ${({ theme: { border, color } }) =>
-    border.default + color.brandBorderDefault};
-  color: ${({ theme: { color } }) => color.brandTextWeak};
+  border: ${({ theme }) =>
+    theme.border.default + theme.color.brandBorderDefault};
+  color: ${({ theme }) => theme.color.brandTextWeak};
 
   img {
-    filter: ${({ theme: { iconFilter } }) => iconFilter.brandTextWeak};
+    filter: ${({ theme }) => theme.iconFilter.brandTextWeak};
   }
 `;
 
 const GhostButton = styled(StyledButton)<{ $selected?: boolean }>`
-  font: ${({ theme: { font }, $size, $selected }) => {
-    const fontSize = $size === "large" ? 20 : $size === "medium" ? 16 : 12;
-    const fontType = $selected ? "selectedBold" : "availableMedium";
-
-    return font[`${fontType}${fontSize}`];
+  font: ${({ theme, $size, $selected }) => {
+    switch ($size) {
+      case "large":
+        return $selected
+          ? theme.font.selectedBold20
+          : theme.font.availableMedium20;
+      case "medium":
+        return $selected
+          ? theme.font.selectedBold16
+          : theme.font.availableMedium16;
+      case "small":
+        return $selected
+          ? theme.font.selectedBold12
+          : theme.font.availableMedium12;
+      default:
+        return "";
+    }
   }};
-  color: ${({ theme: { color }, $selected }) =>
-    $selected ? color.neutralTextStrong : color.neutralTextDefault};
+  color: ${({ theme, $selected }) =>
+    $selected ? theme.color.neutralTextStrong : theme.color.neutralTextDefault};
 
   img {
-    filter: ${({ theme: { iconFilter }, $selected }) =>
-      $selected ? iconFilter.neutralTextStrong : iconFilter.neutralTextDefault};
+    filter: ${({ theme, $selected }) =>
+      $selected
+        ? theme.iconFilter.neutralTextStrong
+        : theme.iconFilter.neutralTextDefault};
   }
 `;

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -1,15 +1,15 @@
 import { ButtonHTMLAttributes } from "react";
 import { styled } from "styled-components";
 
-interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
-  size: "small" | "medium" | "large";
-  buttonType: "container" | "outline" | "ghost";
-  flexible?: "flexible" | "fixed";
+type ButtonProps = {
+  size: "S" | "M" | "L";
+  buttonType: "Container" | "Outline" | "Ghost";
+  flexible?: "Flexible" | "Fixed";
   icon?: string;
   selected?: boolean;
-}
+};
 
-export default function Button({
+export function Button({
   size,
   buttonType,
   flexible,
@@ -17,11 +17,11 @@ export default function Button({
   selected,
   children,
   ...props
-}: ButtonProps) {
+}: ButtonProps & ButtonHTMLAttributes<HTMLButtonElement>) {
   const buttonMap = {
-    container: ConatinerButton,
-    outline: OutlineButton,
-    ghost: GhostButton,
+    Container: ConatinerButton,
+    Outline: OutlineButton,
+    Ghost: GhostButton,
   };
 
   const ButtonComponent = buttonMap[buttonType];
@@ -29,7 +29,7 @@ export default function Button({
   return (
     <ButtonComponent
       $size={size}
-      $flexible={flexible}
+      $flexible={flexible === "Flexible"}
       $selected={selected}
       {...props}
     >
@@ -42,19 +42,19 @@ export default function Button({
 }
 
 const StyledButton = styled.button<{
-  $size: "small" | "medium" | "large";
-  $flexible?: "flexible" | "fixed";
+  $size: "S" | "M" | "L";
+  $flexible?: boolean;
 }>`
   width: ${({ $size, $flexible }) => {
-    if ($flexible === "flexible") {
+    if ($flexible) {
       return "fit-content";
     }
     switch ($size) {
-      case "large":
+      case "L":
         return "240px";
-      case "medium":
+      case "M":
         return "184px";
-      case "small":
+      case "S":
         return "128px";
       default:
         return "";
@@ -62,27 +62,26 @@ const StyledButton = styled.button<{
   }};
   height: ${({ $size }) => {
     switch ($size) {
-      case "large":
+      case "L":
         return "56px";
-      case "medium":
+      case "M":
         return "48px";
-      case "small":
+      case "S":
         return "40px";
       default:
         return "";
     }
   }};
-  padding: ${({ $flexible }) =>
-    $flexible === "flexible" ? "0 24px 0 24px" : ""};
+  padding: ${({ $flexible }) => ($flexible ? "0 24px 0 24px" : "")};
   border-radius: ${({ theme, $size }) =>
-    $size === "large" ? theme.radius.large : theme.radius.medium};
+    $size === "L" ? theme.radius.large : theme.radius.medium};
   font: ${({ theme, $size }) => {
     switch ($size) {
-      case "large":
+      case "L":
         return theme.font.availableMedium20;
-      case "medium":
+      case "M":
         return theme.font.availableMedium16;
-      case "small":
+      case "S":
         return theme.font.availableMedium12;
       default:
         return "";
@@ -139,15 +138,15 @@ const OutlineButton = styled(StyledButton)`
 const GhostButton = styled(StyledButton)<{ $selected?: boolean }>`
   font: ${({ theme, $size, $selected }) => {
     switch ($size) {
-      case "large":
+      case "L":
         return $selected
           ? theme.font.selectedBold20
           : theme.font.availableMedium20;
-      case "medium":
+      case "M":
         return $selected
           ? theme.font.selectedBold16
           : theme.font.availableMedium16;
-      case "small":
+      case "S":
         return $selected
           ? theme.font.selectedBold12
           : theme.font.availableMedium12;

--- a/frontend/src/components/dropdown/DropdownContainer.tsx
+++ b/frontend/src/components/dropdown/DropdownContainer.tsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import { styled } from "styled-components";
+import DropdownIndicator from "./DropdownIndicator";
+import DropdownPanel from "./DropdownPanel";
+
+export default function DropdownContainer() {
+  const [isPanelOpened, setIsPanelOpened] = useState(false);
+
+  return (
+    <StyledContainer>
+      <DropdownIndicator onClick={() => setIsPanelOpened(true)}>
+        버튼
+      </DropdownIndicator>
+      {isPanelOpened && (
+        <>
+          <div
+            className="dropdown__dim"
+            onClick={() => setIsPanelOpened(false)}
+          ></div>
+          <DropdownPanel alignment="left" />
+        </>
+      )}
+    </StyledContainer>
+  );
+}
+
+const StyledContainer = styled.div`
+  position: relative;
+
+  & .dropdown__dim {
+    position: fixed;
+    content: "";
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 50;
+  }
+`;

--- a/frontend/src/components/dropdown/DropdownContainer.tsx
+++ b/frontend/src/components/dropdown/DropdownContainer.tsx
@@ -1,23 +1,46 @@
 import { useState } from "react";
 import { styled } from "styled-components";
-import DropdownIndicator from "./DropdownIndicator";
-import DropdownPanel from "./DropdownPanel";
+import { DropdownIndicator } from "./DropdownIndicator";
+import { DropdownPanel } from "./DropdownPanel";
 
-export default function DropdownContainer() {
+export function DropdownContainer({
+  name,
+  options,
+  showProfile = true,
+  alignment,
+  disabled = false
+}: {
+  name: string;
+  options: {
+    name: string;
+    profile?: string;
+    onClick: () => void;
+  }[];
+  showProfile?: boolean;
+  alignment: "Left" | "Right";
+  disabled?: boolean;
+}) {
   const [isPanelOpened, setIsPanelOpened] = useState(false);
+
+  const openPanel = () => {
+    setIsPanelOpened(true);
+  };
+
+  const closePanel = () => {
+    setIsPanelOpened(false);
+  };
 
   return (
     <StyledContainer>
-      <DropdownIndicator onClick={() => setIsPanelOpened(true)}>
-        버튼
-      </DropdownIndicator>
+      <DropdownIndicator value={name} onClick={openPanel} disabled={disabled} />
       {isPanelOpened && (
         <>
-          <div
-            className="dropdown__dim"
-            onClick={() => setIsPanelOpened(false)}
-          ></div>
-          <DropdownPanel alignment="left" />
+          <div className="dropdown__dim" onClick={closePanel}></div>
+          <DropdownPanel
+            showProfile={showProfile}
+            alignment={alignment}
+            options={options}
+          />
         </>
       )}
     </StyledContainer>
@@ -25,6 +48,7 @@ export default function DropdownContainer() {
 }
 
 const StyledContainer = styled.div`
+  width: fit-content;
   position: relative;
 
   & .dropdown__dim {

--- a/frontend/src/components/dropdown/DropdownIndicator.tsx
+++ b/frontend/src/components/dropdown/DropdownIndicator.tsx
@@ -25,19 +25,19 @@ const StyledButton = styled.button`
   width: 80px;
   height: 32px;
   border-radius: 20px;
-  font: ${({ theme: { font } }) => font.availableMedium16};
-  color: ${({ theme: { color } }) => color.neutralTextDefault};
+  font: ${({ theme }) => theme.font.availableMedium16};
+  color: ${({ theme }) => theme.color.neutralTextDefault};
 
   &:hover {
-    opacity: ${({ theme: { opacity } }) => opacity.hover};
+    opacity: ${({ theme }) => theme.opacity.hover};
   }
 
   &:active {
-    opacity: ${({ theme: { opacity } }) => opacity.press};
+    opacity: ${({ theme }) => theme.opacity.press};
   }
 
   &:disabled {
-    opacity: ${({ theme: { opacity } }) => opacity.disabled};
+    opacity: ${({ theme }) => theme.opacity.disabled};
   }
 
   span {

--- a/frontend/src/components/dropdown/DropdownIndicator.tsx
+++ b/frontend/src/components/dropdown/DropdownIndicator.tsx
@@ -1,14 +1,16 @@
 import { styled } from "styled-components";
 
 export default function DropdownIndicator({
-  disabled,
   children,
+  disabled,
+  onClick,
 }: {
-  disabled?: boolean;
   children: string;
+  disabled?: boolean;
+  onClick?: () => void;
 }) {
   return (
-    <StyledButton disabled={disabled}>
+    <StyledButton {...{ disabled, onClick }}>
       <span>{children}</span>
       <img src="src/assets/chevronDown.svg" alt="드롭다운 열기" />
     </StyledButton>

--- a/frontend/src/components/dropdown/DropdownIndicator.tsx
+++ b/frontend/src/components/dropdown/DropdownIndicator.tsx
@@ -1,17 +1,17 @@
 import { styled } from "styled-components";
 
-export default function DropdownIndicator({
-  children,
-  disabled,
+export function DropdownIndicator({
+  value,
+  disabled = false,
   onClick,
 }: {
-  children: string;
+  value: string;
   disabled?: boolean;
   onClick?: () => void;
-}) {
+} & React.HTMLAttributes<HTMLButtonElement>) {
   return (
-    <StyledButton {...{ disabled, onClick }}>
-      <span>{children}</span>
+    <StyledButton onClick={onClick} disabled={disabled}>
+      <span>{value}</span>
       <img src="src/assets/chevronDown.svg" alt="드롭다운 열기" />
     </StyledButton>
   );

--- a/frontend/src/components/dropdown/DropdownIndicator.tsx
+++ b/frontend/src/components/dropdown/DropdownIndicator.tsx
@@ -1,0 +1,44 @@
+import { styled } from "styled-components";
+
+export default function DropdownIndicator({
+  disabled,
+  children,
+}: {
+  disabled?: boolean;
+  children: string;
+}) {
+  return (
+    <StyledButton disabled={disabled}>
+      <span>{children}</span>
+      <img src="src/assets/chevronDown.svg" alt="드롭다운 열기" />
+    </StyledButton>
+  );
+}
+
+const StyledButton = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+  width: 80px;
+  height: 32px;
+  border-radius: 20px;
+  font: ${({ theme: { font } }) => font.availableMedium16};
+  color: ${({ theme: { color } }) => color.neutralTextDefault};
+
+  &:hover {
+    opacity: ${({ theme: { opacity } }) => opacity.hover};
+  }
+
+  &:active {
+    opacity: ${({ theme: { opacity } }) => opacity.press};
+  }
+
+  &:disabled {
+    opacity: ${({ theme: { opacity } }) => opacity.disabled};
+  }
+
+  span {
+    width: 60px;
+  }
+`;

--- a/frontend/src/components/dropdown/DropdownPanel.tsx
+++ b/frontend/src/components/dropdown/DropdownPanel.tsx
@@ -1,0 +1,97 @@
+import { useState } from "react";
+import { styled } from "styled-components";
+
+export default function DropdownPanel() {
+  const [selectedOptionIndex, setSelectedOptionIndex] = useState(-1);
+
+  return (
+    <StyledPanel>
+      <div className="dropdown__header">헤더</div>
+      <ul className="dropdown__option-container">
+        {["option1", "option2", "option3"].map((option, index) => (
+          <li
+            className={`dropdown__option ${
+              selectedOptionIndex === index && "selected"
+            }`}
+            key={index}
+            onClick={() => setSelectedOptionIndex(index)}
+          >
+            <DropdownOption selected={selectedOptionIndex === index}>
+              {option}
+            </DropdownOption>
+          </li>
+        ))}
+      </ul>
+    </StyledPanel>
+  );
+}
+
+function DropdownOption({
+  showProfile = true,
+  selected,
+  children,
+}: {
+  showProfile?: boolean;
+  selected: boolean;
+  children: string;
+}) {
+  return (
+    <>
+      {showProfile && <img src="src/assets/userImageSmall.svg" alt="" />}
+      <span>{children}</span>
+      <img
+        src={`src/assets/check${selected ? "On" : "Off"}Circle.svg`}
+        alt={selected ? "선택된 옵션" : "선택되지 않은 옵션"}
+      />
+    </>
+  );
+}
+
+const StyledPanel = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  width: 240px;
+  border: ${({ theme: { border, color } }) =>
+    border.default + color.neutralBorderDefault};
+  border-radius: ${({ theme: { radius } }) => radius.large};
+
+  & .dropdown__header {
+    border-radius: ${({ theme: { radius } }) =>
+      `${radius.large} ${radius.large} 0px 0px`};
+    padding: 8px 16px;
+    background-color: ${({ theme: { color } }) => color.neutralSurfaceDefault};
+    font: ${({ theme: { font } }) => font.displayMedium12};
+    color: ${({ theme: { color } }) => color.neutralTextWeak};
+  }
+
+  & .dropdown__option {
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    height: 40px;
+    padding: 8px 16px;
+    background-color: ${({ theme: { color } }) => color.neutralSurfaceStrong};
+    font: ${({ theme: { font } }) => font.availableMedium16};
+    color: ${({ theme: { color } }) => color.neutralTextDefault};
+
+    &.selected {
+      font: ${({ theme: { font } }) => font.selectedBold16};
+      color: ${({ theme: { color } }) => color.neutralTextStrong};
+    }
+
+    &:hover {
+      background-color: ${({ theme: { color } }) => color.neutralSurfaceBold};
+    }
+
+    &:last-child {
+      border-radius: ${({ theme: { radius } }) =>
+        `0px 0px ${radius.large} ${radius.large}`};
+    }
+
+    & span {
+      flex-grow: 1;
+    }
+  }
+`;

--- a/frontend/src/components/dropdown/DropdownPanel.tsx
+++ b/frontend/src/components/dropdown/DropdownPanel.tsx
@@ -1,11 +1,15 @@
 import { useState } from "react";
 import { styled } from "styled-components";
 
-export default function DropdownPanel() {
+export default function DropdownPanel({
+  alignment,
+}: {
+  alignment: "left" | "right";
+}) {
   const [selectedOptionIndex, setSelectedOptionIndex] = useState(-1);
 
   return (
-    <StyledPanel>
+    <StyledPanel alignment={alignment}>
       <div className="dropdown__header">헤더</div>
       <ul className="dropdown__option-container">
         {["option1", "option2", "option3"].map((option, index) => (
@@ -28,16 +32,20 @@ export default function DropdownPanel() {
 
 function DropdownOption({
   showProfile = true,
+  profile,
   selected,
   children,
 }: {
   showProfile?: boolean;
+  profile?: string;
   selected: boolean;
   children: string;
 }) {
   return (
     <>
-      {showProfile && <img src="src/assets/userImageSmall.svg" alt="" />}
+      {showProfile && (
+        <img src={profile ?? "src/assets/userImageSmall.svg"} alt="" />
+      )}
       <span>{children}</span>
       <img
         src={`src/assets/check${selected ? "On" : "Off"}Circle.svg`}
@@ -47,7 +55,12 @@ function DropdownOption({
   );
 }
 
-const StyledPanel = styled.div`
+const StyledPanel = styled.div<{ alignment: "left" | "right" }>`
+  position: absolute;
+  left: ${({ alignment }) => (alignment === "left" ? "0" : "auto")};
+  right: ${({ alignment }) => (alignment === "right" ? "0" : "auto")};
+  z-index: 100;
+
   display: flex;
   flex-direction: column;
   gap: 1px;
@@ -83,6 +96,7 @@ const StyledPanel = styled.div`
 
     &:hover {
       background-color: ${({ theme: { color } }) => color.neutralSurfaceBold};
+      cursor: pointer;
     }
 
     &:last-child {

--- a/frontend/src/components/dropdown/DropdownPanel.tsx
+++ b/frontend/src/components/dropdown/DropdownPanel.tsx
@@ -1,27 +1,44 @@
 import { useState } from "react";
 import { styled } from "styled-components";
 
-export default function DropdownPanel({
+export function DropdownPanel({
+  showProfile = true,
   alignment,
+  options,
 }: {
-  alignment: "left" | "right";
+  showProfile?: boolean;
+  alignment: "Left" | "Right";
+  options: {
+    name: string;
+    profile?: string;
+    onClick: () => void;
+  }[];
 }) {
   const [selectedOptionIndex, setSelectedOptionIndex] = useState(-1);
+
+  const onOptionClick = (index: number, callback: () => void) => {
+    callback();
+    setSelectedOptionIndex(index);
+  }
 
   return (
     <StyledPanel $alignment={alignment}>
       <div className="dropdown__header">헤더</div>
       <ul className="dropdown__option-container">
-        {["option1", "option2", "option3"].map((option, index) => (
+        {options.map((option, index) => (
           <li
             className={`dropdown__option ${
               selectedOptionIndex === index && "selected"
             }`}
             key={index}
-            onClick={() => setSelectedOptionIndex(index)}
+            onClick={() => onOptionClick(index, option.onClick)}
           >
-            <DropdownOption selected={selectedOptionIndex === index}>
-              {option}
+            <DropdownOption
+              showProfile={showProfile}
+              profile={option.profile}
+              selected={selectedOptionIndex === index}
+            >
+              {option.name}
             </DropdownOption>
           </li>
         ))}
@@ -44,7 +61,7 @@ function DropdownOption({
   return (
     <>
       {showProfile && (
-        <img src={profile ?? "src/assets/userImageSmall.svg"} alt="" />
+        <img src={profile ? profile : "src/assets/userImageSmall.svg"} alt="" />
       )}
       <span>{children}</span>
       <img
@@ -55,10 +72,10 @@ function DropdownOption({
   );
 }
 
-const StyledPanel = styled.div<{ $alignment: "left" | "right" }>`
+const StyledPanel = styled.div<{ $alignment: "Left" | "Right" }>`
   position: absolute;
-  left: ${({ $alignment }) => ($alignment === "left" ? "0" : "auto")};
-  right: ${({ $alignment }) => ($alignment === "right" ? "0" : "auto")};
+  left: ${({ $alignment }) => ($alignment === "Left" ? "0" : "auto")};
+  right: ${({ $alignment }) => ($alignment === "Right" ? "0" : "auto")};
   z-index: 100;
 
   display: flex;

--- a/frontend/src/components/dropdown/DropdownPanel.tsx
+++ b/frontend/src/components/dropdown/DropdownPanel.tsx
@@ -9,7 +9,7 @@ export default function DropdownPanel({
   const [selectedOptionIndex, setSelectedOptionIndex] = useState(-1);
 
   return (
-    <StyledPanel alignment={alignment}>
+    <StyledPanel $alignment={alignment}>
       <div className="dropdown__header">헤더</div>
       <ul className="dropdown__option-container">
         {["option1", "option2", "option3"].map((option, index) => (
@@ -55,27 +55,28 @@ function DropdownOption({
   );
 }
 
-const StyledPanel = styled.div<{ alignment: "left" | "right" }>`
+const StyledPanel = styled.div<{ $alignment: "left" | "right" }>`
   position: absolute;
-  left: ${({ alignment }) => (alignment === "left" ? "0" : "auto")};
-  right: ${({ alignment }) => (alignment === "right" ? "0" : "auto")};
+  left: ${({ $alignment }) => ($alignment === "left" ? "0" : "auto")};
+  right: ${({ $alignment }) => ($alignment === "right" ? "0" : "auto")};
   z-index: 100;
 
   display: flex;
   flex-direction: column;
   gap: 1px;
   width: 240px;
-  border: ${({ theme: { border, color } }) =>
-    border.default + color.neutralBorderDefault};
-  border-radius: ${({ theme: { radius } }) => radius.large};
+  border: ${({ theme }) =>
+    theme.border.default + theme.color.neutralBorderDefault};
+  border-radius: ${({ theme }) => theme.radius.large};
+  background-color: ${({ theme }) => theme.color.neutralBorderDefault};
 
   & .dropdown__header {
-    border-radius: ${({ theme: { radius } }) =>
-      `${radius.large} ${radius.large} 0px 0px`};
+    border-radius: ${({ theme }) =>
+      `${theme.radius.large} ${theme.radius.large} 0px 0px`};
     padding: 8px 16px;
-    background-color: ${({ theme: { color } }) => color.neutralSurfaceDefault};
-    font: ${({ theme: { font } }) => font.displayMedium12};
-    color: ${({ theme: { color } }) => color.neutralTextWeak};
+    background-color: ${({ theme }) => theme.color.neutralSurfaceDefault};
+    font: ${({ theme }) => theme.font.displayMedium12};
+    color: ${({ theme }) => theme.color.neutralTextWeak};
   }
 
   & .dropdown__option {
@@ -85,23 +86,23 @@ const StyledPanel = styled.div<{ alignment: "left" | "right" }>`
     gap: 8px;
     height: 40px;
     padding: 8px 16px;
-    background-color: ${({ theme: { color } }) => color.neutralSurfaceStrong};
-    font: ${({ theme: { font } }) => font.availableMedium16};
-    color: ${({ theme: { color } }) => color.neutralTextDefault};
+    background-color: ${({ theme }) => theme.color.neutralSurfaceStrong};
+    font: ${({ theme }) => theme.font.availableMedium16};
+    color: ${({ theme }) => theme.color.neutralTextDefault};
 
     &.selected {
-      font: ${({ theme: { font } }) => font.selectedBold16};
-      color: ${({ theme: { color } }) => color.neutralTextStrong};
+      font: ${({ theme }) => theme.font.selectedBold16};
+      color: ${({ theme }) => theme.color.neutralTextStrong};
     }
 
     &:hover {
-      background-color: ${({ theme: { color } }) => color.neutralSurfaceBold};
+      background-color: ${({ theme }) => theme.color.neutralSurfaceBold};
       cursor: pointer;
     }
 
     &:last-child {
-      border-radius: ${({ theme: { radius } }) =>
-        `0px 0px ${radius.large} ${radius.large}`};
+      border-radius: ${({ theme }) =>
+        `0px 0px ${theme.radius.large} ${theme.radius.large}`};
     }
 
     & span {

--- a/frontend/src/constants/designSystem.ts
+++ b/frontend/src/constants/designSystem.ts
@@ -9,9 +9,9 @@ const font = {
   selectedBold20: "700 20px/32px Pretendard, sans-serif",
   selectedBold16: "700 16px/24px Pretendard, sans-serif",
   selectedBold12: "700 16px/24px Pretendard, sans-serif",
-  availableBold20: "500 20px/32px Pretendard, sans-serif",
-  availableBold16: "500 16px/24px Pretendard, sans-serif",
-  availableBold12: "500 12px/16px Pretendard, sans-serif",
+  availableMedium20: "500 20px/32px Pretendard, sans-serif",
+  availableMedium16: "500 16px/24px Pretendard, sans-serif",
+  availableMedium12: "500 12px/16px Pretendard, sans-serif",
 };
 
 const color = {
@@ -101,11 +101,20 @@ const mode = {
 };
 
 export const designSystem = {
-  font,
-  color,
-  radius,
-  border,
-  opacity,
-  light: mode.light,
-  dark: mode.dark,
+  light: {
+    font,
+    radius,
+    border,
+    opacity,  
+    color: mode.light,
+    dropShadow: mode.light.dropShadow
+  },
+  dark: {
+    font,
+    radius,
+    border,
+    opacity,
+    color: mode.dark,
+    dropShadow: mode.dark.dropShadow
+  }
 };

--- a/frontend/src/constants/designSystem.ts
+++ b/frontend/src/constants/designSystem.ts
@@ -49,31 +49,8 @@ const opacity = {
   disabled: "0.32",
 };
 
-const iconFilter = {
-  light: {
-    neutralTextDefault:
-      "brightness(0) saturate(100%) invert(31%) sepia(8%) saturate(1775%) hue-rotate(197deg) brightness(93%) contrast(91%)",
-    neutralTextStrong:
-      "brightness(0) saturate(100%) invert(8%) sepia(6%) saturate(6138%) hue-rotate(203deg) brightness(94%) contrast(98%)",
-    brandTextWeak:
-      "brightness(0) saturate(100%) invert(30%) sepia(47%) saturate(3393%) hue-rotate(200deg) brightness(103%) contrast(112%)",
-    brandTextDefault:
-      "brightness(0) saturate(100%) invert(94%) sepia(32%) saturate(0%) hue-rotate(6deg) brightness(105%) contrast(99%)",
-  },
-  dark: {
-    neutralTextDefault:
-      "brightness(0) saturate(100%) invert(85%) sepia(17%) saturate(218%) hue-rotate(195deg) brightness(91%) contrast(85%)",
-    neutralTextStrong:
-      "brightness(0) saturate(100%) invert(94%) sepia(32%) saturate(0%) hue-rotate(6deg) brightness(105%) contrast(99%)",
-    brandTextWeak:
-      "brightness(0) saturate(100%) invert(30%) sepia(47%) saturate(3393%) hue-rotate(200deg) brightness(103%) contrast(112%)",
-    brandTextDefault:
-      "brightness(0) saturate(100%) invert(94%) sepia(32%) saturate(0%) hue-rotate(6deg) brightness(105%) contrast(99%)",
-  },
-};
-
-const mode = {
-  light: {
+const light = {
+  color: {
     neutralTextWeak: color.grayScale600,
     neutralTextDefault: color.grayScale700,
     neutralTextStrong: color.grayScale900,
@@ -96,10 +73,22 @@ const mode = {
     paletteBlue: color.accentBlue,
     paletteNavy: color.accentNavy,
     paletteRed: color.accentRed,
-
-    dropShadow: "0 0 8px 0 rgba(20, 20, 43, 0.04)",
   },
-  dark: {
+  dropShadow: "0 0 8px 0 rgba(20, 20, 43, 0.04)",
+  iconFilter: {
+    neutralTextDefault:
+      "brightness(0) saturate(100%) invert(31%) sepia(8%) saturate(1775%) hue-rotate(197deg) brightness(93%) contrast(91%)",
+    neutralTextStrong:
+      "brightness(0) saturate(100%) invert(8%) sepia(6%) saturate(6138%) hue-rotate(203deg) brightness(94%) contrast(98%)",
+    brandTextWeak:
+      "brightness(0) saturate(100%) invert(30%) sepia(47%) saturate(3393%) hue-rotate(200deg) brightness(103%) contrast(112%)",
+    brandTextDefault:
+      "brightness(0) saturate(100%) invert(94%) sepia(32%) saturate(0%) hue-rotate(6deg) brightness(105%) contrast(99%)",
+  }
+};
+
+const dark = {
+  color: {
     neutralTextWeak: color.grayScale500,
     neutralTextDefault: color.grayScale400,
     neutralTextStrong: color.grayScale50,
@@ -122,9 +111,18 @@ const mode = {
     paletteBlue: color.accentBlue,
     paletteNavy: color.accentNavy,
     paletteRed: color.accentRed,
-
-    dropShadow: "0 0 16px 0 rgba(20, 20, 43, 0.8)",
   },
+  dropShadow: "0 0 16px 0 rgba(20, 20, 43, 0.8)",
+  iconFilter: {
+    neutralTextDefault:
+      "brightness(0) saturate(100%) invert(85%) sepia(17%) saturate(218%) hue-rotate(195deg) brightness(91%) contrast(85%)",
+    neutralTextStrong:
+      "brightness(0) saturate(100%) invert(94%) sepia(32%) saturate(0%) hue-rotate(6deg) brightness(105%) contrast(99%)",
+    brandTextWeak:
+      "brightness(0) saturate(100%) invert(30%) sepia(47%) saturate(3393%) hue-rotate(200deg) brightness(103%) contrast(112%)",
+    brandTextDefault:
+      "brightness(0) saturate(100%) invert(94%) sepia(32%) saturate(0%) hue-rotate(6deg) brightness(105%) contrast(99%)",
+  }
 };
 
 export const designSystem = {
@@ -133,17 +131,13 @@ export const designSystem = {
     radius,
     border,
     opacity,
-    iconFilter: iconFilter.light,
-    color: mode.light,
-    dropShadow: mode.light.dropShadow,
+    ...light
   },
   dark: {
     font,
     radius,
     border,
     opacity,
-    iconFilter: iconFilter.dark,
-    color: mode.dark,
-    dropShadow: mode.dark.dropShadow,
+    ...dark
   },
 };


### PR DESCRIPTION
## Description

- Dropdown 컴포넌트 UI

## Key Changes

![image](https://github.com/masters2023-3rd-project-bugbusters/issue-tracker-max/assets/60080167/995c994a-4515-4d92-8fef-091f1e7d0f0e)
![image](https://github.com/masters2023-3rd-project-bugbusters/issue-tracker-max/assets/60080167/1a335d27-54af-418a-83e3-07e9339fc0ef)

- 드롭다운 열기 버튼: `DropdownIndicator`
- 드롭다운 패널: `DropdownPanel`
- 드롭다운 닫기 동작을 위해서 클릭 이벤트를 등록할 바깥 영역을 `DropdownContainer` 내부에 'dropdown__dim'라는 클래스 이름을 붙여 생성
- `DropdownContainer`를 그대로 사용하는 것을 가정

### props 형태

```
name: string;
options: {
  name: string;
  profile?: string;
  onClick: () => void;
}[];
showProfile?: boolean;
alignment: "Left" | "Right";
disabled?: boolean;
```

## To Reviewrs

- Filter Bar 외에는 대부분의 환경에서 그대로 사용하는 것 같아서 여러가지 사용 방법을 고려하기보다는 고정된 형태로 사용할 것을 가정했습니다. 
- App.tsx에 예시가 추가되어 있습니다.
- Styled component에서 theme을 사용하는 부분의 코드를 `${({ theme }) => theme.color.neutralBorderDefault}`와 같이 수정했습니다.
- Design System의 color에 `dropShadow`가 포함되어 이를 수정하기 위해 코드를 수정했습니다(theme을 사용하는 것에는 아무 영향이 없습니다).

## Issues

- #16 

## Next Step


