### PR TITLE
[fe] TextInput 컴포넌트 UI 구현 

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { ThemeProvider } from "styled-components";
 import Button from "./components/Button";
+import { TextInput } from "./components/TextInput";
 import { designSystem } from "./constants/designSystem";
 
 export default function App() {
@@ -12,7 +13,15 @@ export default function App() {
 
   return (
     <ThemeProvider theme={designSystem[themeMode]}>
-      <div>hello world</div>
+      <TextInputTest />
+      <ButtonTest onClick={onClick} />
+    </ThemeProvider>
+  );
+}
+
+function ButtonTest({ onClick }: { onClick: () => void }) {
+  return (
+    <div>
       <Button
         icon="alertCircle"
         size="medium"
@@ -40,6 +49,36 @@ export default function App() {
       >
         모드 변경
       </Button>
-    </ThemeProvider>
+    </div>
+  );
+}
+
+function TextInputTest() {
+  return (
+    <div>
+      <div>Enable/Active</div>
+      <TextInput
+        size="L"
+        label="아이디"
+        caption="영문, 숫자 조합 6자 이상 12자 이하"
+        value="Enable/Active"
+      />
+      <div>Disabled</div>
+      <TextInput
+        size="L"
+        label="아이디"
+        caption="영문, 숫자 조합 6자 이상 12자 이하"
+        disabled={true}
+        value="Disabled"
+      />
+      <div>Error</div>
+      <TextInput
+        size="L"
+        label="아이디"
+        caption="영문, 숫자 조합 6자 이상 12자 이하"
+        validator={(value) => /^[a-zA-Z0-9]{6,12}$/.test(value)}
+        value="Error"
+      />
+    </div>
   );
 }

--- a/frontend/src/components/TextInput.tsx
+++ b/frontend/src/components/TextInput.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useState } from "react";
+import styled from "styled-components";
+
+type TextInputProps = {
+  width?: number;
+  size: "L" | "S";
+  value?: string;
+  label: string;
+  caption?: string;
+  disabled?: boolean;
+  validator?: (value: string) => boolean;
+};
+
+type TextInputState = "Enabled" | "Active" | "Disabled" | "Error";
+
+type InputProps = {
+  $state: TextInputState;
+};
+
+type InputContainerProps = {
+  $width: number;
+  $size: "L" | "S";
+  $state: TextInputState;
+};
+
+export function TextInput({
+  width = 254,
+  size,
+  value: initialValue = "",
+  label,
+  caption,
+  disabled = false,
+  validator,
+}: TextInputProps) {
+  const [state, setState] = useState<TextInputState>(
+    disabled ? "Disabled" : "Enabled",
+  );
+  const [inputValue, setInputValue] = useState(initialValue);
+
+  useEffect(() => {
+    if (validator) {
+      setState(validator(inputValue) ? "Enabled" : "Error");
+    }
+  }, [inputValue, validator]);
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(event.target.value);
+  };
+
+  const handleInputFocus = () => {
+    if (state !== "Error") {
+      setState("Active");
+    }
+  };
+
+  const handleInputBlur = () => {
+    if (state !== "Error") {
+      setState(disabled ? "Disabled" : "Enabled");
+    }
+  };
+
+  return (
+    <Div $state={state}>
+      <InputContainer $width={width} $size={size} $state={state}>
+        {inputValue && <StyledSpan>{label}</StyledSpan>}
+        <Input
+          placeholder={label}
+          value={inputValue}
+          onChange={handleInputChange}
+          onFocus={handleInputFocus}
+          onBlur={handleInputBlur}
+          disabled={state === "Disabled"}
+          $state={state}
+        />
+      </InputContainer>
+      {caption && <Caption $state={state}>{caption}</Caption>}
+    </Div>
+  );
+}
+
+const Div = styled.div<{ $state: TextInputState }>`
+  display: flex;
+  width: 288px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  flex-shrink: 0;
+  opacity: ${(props) => (props.$state === "Disabled" ? 0.2 : 1)};
+  background: ${({ theme: { color } }) => color.grayScale50};
+`;
+
+const InputContainer = styled.div<InputContainerProps>`
+  display: flex;
+  width: ${({ $width }) => $width}px;
+  height: ${({ $size }) => ($size === "L" ? "56px" : "40px")};
+  padding: 0px 16px;
+  justify-content: center;
+  align-self: stretch;
+  flex-direction: ${({ $size }) => ($size === "L" ? "column" : "")};
+  align-items: ${({ $size }) => ($size === "L" ? "flex-start" : "center")};
+  border-radius: ${({ theme }) => theme.radius.large};
+  box-sizing: border-box;
+  background: ${({ $state, theme }) => {
+    switch ($state) {
+      case "Enabled":
+        return theme.color.neutralSurfaceBold;
+      case "Active":
+      case "Error":
+        return theme.color.neutralSurfaceStrong;
+      default:
+        return theme.color.neutralSurfaceBold;
+    }
+  }};
+  border: ${({ theme, $state }) => {
+    switch ($state) {
+      case "Active":
+        return `1px solid ${theme.color.neutralBorderDefaultActive}`;
+      case "Error":
+        return `1px solid ${theme.color.dangerBorderDefault}`;
+      default:
+        return "";
+    }
+  }};
+`;
+
+const StyledSpan = styled.span`
+  width: 64px;
+  color: ${({ theme }) => theme.color.neutralTextWeak};
+  font: ${({ theme }) => theme.font.displayMedium12};
+`;
+
+const Input = styled.input<InputProps>`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  border: none;
+  &:focus {
+    outline: none;
+  }
+  font: ${({ theme }) => theme.font.displayMedium16};
+  color: ${({ theme, $state }) => {
+    switch ($state) {
+      case "Enabled":
+      case "Disabled":
+      case "Error":
+        return theme.color.neutralTextDefault;
+      case "Active":
+        return theme.color.neutralTextStrong;
+      default:
+        return theme.color.neutralTextDefault;
+    }
+  }};
+  background: none;
+  &::placeholder {
+    color: ${({ theme }) => theme.color.neutralTextWeak};
+  }
+  &:-ms-input-placeholder {
+    color: ${({ theme }) => theme.color.neutralTextWeak};
+  }
+  &::-ms-input-placeholder {
+    color: ${({ theme }) => theme.color.neutralTextWeak};
+  }
+  &::-webkit-input-placeholder {
+    color: ${({ theme }) => theme.color.neutralTextWeak};
+  }
+`;
+
+const Caption = styled.span<{ $state: TextInputState }>`
+  display: flex;
+  padding-left: 0px;
+  align-items: flex-start;
+  align-self: stretch;
+  padding-left: 16px;
+  color: ${({ theme, $state }) =>
+    $state === "Error"
+      ? theme.color.dangerTextDefault
+      : theme.color.neutralTextWeak};
+  font: ${({ theme }) => theme.font.displayMedium12};
+`;


### PR DESCRIPTION
## Description
- TextInput 컴포넌트 UI

## Key Changes
```ts
  width?: number;
  size: "L" | "S";
  value?: string;
  label: string;
  caption?: string;
  disabled?: boolean;
  validator?: (value: string) => boolean;
```
위와 같은 props를 받습니다.
필요 상황에 맞는 props를 전달하면 됩니다.

**validator는 피그마에 없던 값입니다.**
이 값을 추가한 이유는 caption에 맞는 조건을 함께 넘겨서 input에 입력된 값이 caption에 써있는 조건과 일치하지 않으면
state를 Error로 만들기 위해서 입니다.

``` ts
"Enabled" | "Active" | "Disabled" | "Error"
```
그리고 TextInput은 state를 가지고 있는데 state에 따라서 css가 다르게 적용됩니다.

위 4가지 state의 경우를 테스트할 수 있는 코드를 app.tsx에 추가했습니다.

## To Reviewrs
css를 여러 조건에 맞게 정해주는 부분이 상당히 복잡합니다.
간단히 할 수 있는 로직이 있는지 확인 부탁드립니다.

## Next Step

