### PR TITLE
[fe] TabButton 컴포넌트 구현

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="shortcut icon" href="./public/BugBusters.jpeg">
+    <link rel="shortcut icon" href="/BugBusters.jpeg">
     <link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.8/dist/web/static/pretendard.css" />
     <title>BugBusters</title>
   </head>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { ThemeProvider } from "styled-components";
 import { Button } from "./components/Button";
+import { TabButton } from "./components/TabButton";
 import { TextInput } from "./components/TextInput";
 import { DropdownContainer } from "./components/dropdown/DropdownContainer";
 import { designSystem } from "./constants/designSystem";
@@ -14,9 +15,10 @@ export default function App() {
 
   return (
     <ThemeProvider theme={designSystem[themeMode]}>
-      <DropdownTest />
       <TextInputTest />
       <ButtonTest onClick={onClick} />
+      <TabButtonTest />
+      <DropdownTest />
     </ThemeProvider>
   );
 }
@@ -123,8 +125,30 @@ function DropdownTest() {
       },
     },
   ];
-  return (<>
-    <DropdownContainer name="필터" options={options} alignment="Left" />
-    <DropdownContainer name="필터" options={options} alignment="Right" />
-  </>);
+  return (
+    <>
+      <DropdownContainer name="필터" options={options} alignment="Left" />
+      <DropdownContainer name="필터" options={options} alignment="Right" />
+    </>
+  );
+}
+
+function TabButtonTest() {
+  const [tabs, setTabs] = useState([{name: "왼쪽"}, {name: "오른쪽"}]);
+  const [issueStates, setIssueStates] = useState([{name: "열린 이슈", icon: "alertCircle", selected: true}, {name: "닫힌 이슈", icon: "archive"}]);
+
+  const onTabClick = (name: string) => {
+    setTabs(t => t.map(tab => tab.name === name ? {...tab, selected: true} : {...tab, selected: false}));
+  }
+
+  const onIssueStateClick = (name: string) => {
+    setIssueStates(t => t.map(issueState => issueState.name === name ? {...issueState, selected: true} : {...issueState, selected: false}));
+  }
+
+  return (
+    <>
+      <TabButton tabs={tabs} onClick={onTabClick}/>
+      <TabButton tabs={issueStates} onClick={onIssueStateClick}/>
+    </>
+  );
 }

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -28,6 +28,7 @@ export function Button({
 
   return (
     <ButtonComponent
+      className={selected ? "selected" : ""}
       $size={size}
       $flexible={flexible === "Flexible"}
       $selected={selected}

--- a/frontend/src/components/TabButton.tsx
+++ b/frontend/src/components/TabButton.tsx
@@ -1,0 +1,65 @@
+import { styled } from "styled-components";
+import { Button } from "./Button";
+
+export function TabButton({
+  tabs,
+  onClick,
+}: {
+  tabs: {
+    name: string;
+    icon?: string;
+    selected?: boolean;
+  }[];
+  onClick: (name: string) => void;
+}) {
+  const buttons = tabs.map(({ name, icon, selected }) => (
+    <Button
+      key={name}
+      icon={icon}
+      size="M"
+      buttonType="Ghost"
+      flexible="Flexible"
+      selected={selected}
+      onClick={() => onClick(name)}
+    >
+      {name}
+    </Button>
+  ));
+
+  return <StyledTabButton>{buttons}</StyledTabButton>;
+}
+
+const StyledTabButton = styled.div`
+  display: flex;
+  align-items: center;
+  width: 320px;
+  height: 40px;
+  border: ${({ theme }) =>
+    `${theme.border.default} ${theme.color.neutralBorderDefault}`};
+  border-radius: ${({ theme }) => theme.radius.medium};
+  background-color: ${({ theme }) => theme.color.neutralSurfaceDefault};
+
+  & button {
+    flex: 1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+
+    &:first-child {
+      border-right: ${({ theme }) =>
+        `${theme.border.default} ${theme.color.neutralBorderDefault}`};
+      border-radius: ${({ theme }) =>
+        `${theme.radius.medium} 0 0 ${theme.radius.medium}`};
+    }
+
+    &:last-child {
+      border-radius: ${({ theme }) =>
+        `0 ${theme.radius.medium} ${theme.radius.medium} 0`};
+    }
+
+    &.selected {
+      background-color: ${({ theme }) => theme.color.neutralSurfaceBold};
+    }
+  }
+`;

--- a/frontend/src/components/TabButton.tsx
+++ b/frontend/src/components/TabButton.tsx
@@ -12,21 +12,23 @@ export function TabButton({
   }[];
   onClick: (name: string) => void;
 }) {
-  const buttons = tabs.map(({ name, icon, selected }) => (
-    <Button
-      key={name}
-      icon={icon}
-      size="M"
-      buttonType="Ghost"
-      flexible="Flexible"
-      selected={selected}
-      onClick={() => onClick(name)}
-    >
-      {name}
-    </Button>
-  ));
-
-  return <StyledTabButton>{buttons}</StyledTabButton>;
+  return (
+    <StyledTabButton>
+      {tabs.map(({ name, icon, selected }) => (
+        <Button
+          key={name}
+          icon={icon}
+          size="M"
+          buttonType="Ghost"
+          flexible="Flexible"
+          selected={selected}
+          onClick={() => onClick(name)}
+        >
+          {name}
+        </Button>
+      ))}
+    </StyledTabButton>
+  );
 }
 
 const StyledTabButton = styled.div`


### PR DESCRIPTION
## Description

- TabButton 컴포넌트 UI

## Key Changes

![BugBusters_tabButton](https://github.com/masters2023-3rd-project-bugbusters/issue-tracker-max/assets/60080167/7fdc7c15-a321-4e28-afeb-458d3fe3ab53)

- `GhostButton`을 활용해 `TabButton` 컴포넌트를 구현했습니다.
- 선택된 버튼의 배경색, 폰트 두께 변경하기 위해서 `Button` 컴포넌트가 selected=true 인 경우 className를 `selected`로 변경되게 했습니다.
- **props**
  ```
  tabs: {
    name: string;
    icon?: string;
    selected?: boolean;
  }[];
  onClick: (name: string) => void;
  ```

## To Reviewers

- #21 에서 계획했던 것에서 props가 변경되었습니다.
  ```
  tabs: string[];
  onClick: (param: string) => void; // 같은 페이지로 이동
  ```
- return 문 안에서 map 연산을 하지 않고 컴포넌트 함수 본문에서 계산하고 return에서는 호출만 해봤습니다. 반환값이 간결해져서 좋은 것 같은데, 어떠신지 궁금합니다.
- Vite에서 가이드한 대로 `/public/BugBusters.jpeg`에서 `/BugBusters.jpeg`로 favicon 경로를 변경했습니다.

## Issues

- #18 

## Next Step

