### PR TITLE
[fe] InformationTag 컴포넌트 구현

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { ThemeProvider } from "styled-components";
 import { Button } from "./components/Button";
+import { InformationTag } from "./components/InformationTag";
 import { TabButton } from "./components/TabButton";
 import { TextInput } from "./components/TextInput";
 import { DropdownContainer } from "./components/dropdown/DropdownContainer";
@@ -19,6 +20,7 @@ export default function App() {
       <ButtonTest onClick={onClick} />
       <TabButtonTest />
       <DropdownTest />
+      <InformationTagTest />
     </ThemeProvider>
   );
 }
@@ -128,27 +130,72 @@ function DropdownTest() {
   return (
     <>
       <DropdownContainer name="assignee" options={options} alignment="Left" />
-      <DropdownContainer name="milestones" options={options} alignment="Right" />
+      <DropdownContainer
+        name="milestones"
+        options={options}
+        alignment="Right"
+      />
     </>
   );
 }
 
 function TabButtonTest() {
-  const [tabs, setTabs] = useState([{name: "label(3)", icon: "label"}, {name: "milestone(2)", icon: "milestone"}]);
-  const [issueStates, setIssueStates] = useState([{name: "열린 이슈", icon: "alertCircle", selected: true}, {name: "닫힌 이슈", icon: "archive"}]);
+  const [tabs, setTabs] = useState([
+    { name: "label(3)", icon: "label" },
+    { name: "milestone(2)", icon: "milestone" },
+  ]);
+  const [issueStates, setIssueStates] = useState([
+    { name: "열린 이슈", icon: "alertCircle", selected: true },
+    { name: "닫힌 이슈", icon: "archive" },
+  ]);
 
   const onTabClick = (name: string) => {
-    setTabs(t => t.map(tab => tab.name === name ? {...tab, selected: true} : {...tab, selected: false}));
-  }
+    setTabs((t) =>
+      t.map((tab) =>
+        tab.name === name
+          ? { ...tab, selected: true }
+          : { ...tab, selected: false },
+      ),
+    );
+  };
 
   const onIssueStateClick = (name: string) => {
-    setIssueStates(t => t.map(issueState => issueState.name === name ? {...issueState, selected: true} : {...issueState, selected: false}));
-  }
+    setIssueStates((t) =>
+      t.map((issueState) =>
+        issueState.name === name
+          ? { ...issueState, selected: true }
+          : { ...issueState, selected: false },
+      ),
+    );
+  };
 
   return (
     <>
-      <TabButton tabs={tabs} onClick={onTabClick}/>
-      <TabButton tabs={issueStates} onClick={onIssueStateClick}/>
+      <TabButton tabs={tabs} onClick={onTabClick} />
+      <TabButton tabs={issueStates} onClick={onIssueStateClick} />
+    </>
+  );
+}
+
+function InformationTagTest() {
+  return (
+    <>
+      <InformationTag
+        value="열린 이슈"
+        toolTip="Status: Open 긴 이름이 들어가는 경우"
+        icon="alertCircle"
+        size="M"
+        fill="#7F4BFF"
+        fontColor="Light"
+      />
+      <InformationTag value="작성자" toolTip="해당 이슈의 작성자입니다." size="S" fill="#C5C" stroke="Default" />
+      <InformationTag
+        value="documentation"
+        toolTip="문서 작업입니다."
+        size="S"
+        fill="#000FFF"
+        fontColor="Light"
+      />
     </>
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -188,7 +188,7 @@ function InformationTagTest() {
         fill="#7F4BFF"
         fontColor="Light"
       />
-      <InformationTag value="작성자" toolTip="해당 이슈의 작성자입니다." size="S" fill="#C5C" stroke="Default" />
+      <InformationTag value="작성자" toolTip=" " size="S" fill="#C5C" stroke="Default" />
       <InformationTag
         value="documentation"
         toolTip="문서 작업입니다."

--- a/frontend/src/components/InformationTag.tsx
+++ b/frontend/src/components/InformationTag.tsx
@@ -1,0 +1,95 @@
+import { styled } from "styled-components";
+
+export function InformationTag({
+  value,
+  size,
+  toolTip,
+  icon,
+  fill,
+  stroke,
+  fontColor = "Dark",
+}: {
+  value: string;
+  size: "M" | "S";
+  toolTip?: string;
+  icon?: string;
+  fill?: string;
+  stroke?: "Default" | "DefaultActive";
+  fontColor?: "Light" | "Dark";
+}) {
+  return (
+    <StyledInformationTag
+      data-title={toolTip}
+      $size={size}
+      $fill={fill}
+      $stroke={stroke}
+      $darkFont={fontColor === "Dark"}
+    >
+      {icon && <img src={`/src/assets/${icon}.svg`} alt={icon} />}
+      <span>{value}</span>
+    </StyledInformationTag>
+  );
+}
+
+const StyledInformationTag = styled.div<{
+  $size: "M" | "S";
+  $fill?: string;
+  $stroke?: "Default" | "DefaultActive";
+  $darkFont: boolean;
+}>`
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  width: fit-content;
+  height: ${({ $size }) => ($size === "M" ? "32px" : "24px")};
+  padding: ${({ $size }) => ($size === "M" ? "0 16px" : "0 8px")};
+  border: 1px solid
+    ${({ theme, $stroke }) =>
+      $stroke && theme.color[`neutralBorder${$stroke}`]
+        ? theme.color[`neutralBorder${$stroke}`]
+        : "transparent"};
+  border-radius: ${({ theme }) => theme.radius.large};
+  background-color: ${({ theme, $fill }) =>
+    $fill && /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/g.test($fill)
+      ? $fill
+      : theme.color.neutralSurfaceStrong};
+  color: ${({ theme, $darkFont }) =>
+    $darkFont ? theme.color.neutralTextWeak : theme.color.brandTextDefault};
+  font: ${({ theme }) => theme.font.displayMedium12};
+
+  &[data-title] {
+    position: relative;
+  }
+
+  &[data-title]::after {
+    content: attr(data-title);
+    position: absolute;
+    left: 50%;
+    transform: translate(-50%, 100%);
+    padding: 4px 8px;
+    border-radius: 4px;
+    white-space: nowrap;
+    background-color: ${({ theme }) => theme.color.neutralTextStrong};
+    color: ${({ theme }) => theme.color.neutralSurfaceStrong};
+    z-index: 9999;
+    opacity: 0;
+    visibility: hidden;
+  }
+
+  &[data-title]:hover::after {
+    opacity: 1;
+    visibility: visible;
+    transition: all 0.1s ease 0.5s;
+  }
+
+  img {
+    filter: ${({ theme, $darkFont }) =>
+      $darkFont
+        ? theme.iconFilter.neutralTextWeak
+        : theme.iconFilter.brandTextDefault};
+  }
+
+  span {
+    padding: 0px 4px;
+  }
+`;

--- a/frontend/src/components/InformationTag.tsx
+++ b/frontend/src/components/InformationTag.tsx
@@ -3,7 +3,7 @@ import { styled } from "styled-components";
 export function InformationTag({
   value,
   size,
-  toolTip,
+  toolTip = "",
   icon,
   fill,
   stroke,
@@ -19,7 +19,7 @@ export function InformationTag({
 }) {
   return (
     <StyledInformationTag
-      data-title={toolTip}
+      data-title={/^\s*$/.test(toolTip) ? undefined : toolTip}
       $size={size}
       $fill={fill}
       $stroke={stroke}


### PR DESCRIPTION
## Description

InformationTag 컴포넌트 구현

## Key Changes

![BugBusters_informationTag](https://github.com/masters2023-3rd-project-bugbusters/issue-tracker-max/assets/60080167/23145bbe-e668-4e62-ab3d-e74261f7d166)

- InformationTag 컴포넌트
- 툴팁 커스텀 with css

## To Reviewers

- props
  ```
  value: string;
  size: "M" | "S";
  toolTip?: string;
  icon?: string;
  fill?: string;
  stroke?: "Default" | "DefaultActive";
  fontColor?: "Light" | "Dark";
  ```
- 깃헙의 툴팁 색상이 다르길래 css seudo selector로 살짝 적용해봤습니다.
- 툴팁을 입력하지 않거나 공백(띄어쓰기 포함)으로 넘기면 툴팁이 나오지 않습니다.

## Issues

- #29 

## Next Step

다음 진행 사항
