### PR TITLE
[fe] FilterBar 컴포넌트 구현

### DIFF
--- a/frontend/src/components/FilterBar.tsx
+++ b/frontend/src/components/FilterBar.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import { styled } from "styled-components";
+import { TextInput } from "./TextInput";
+import { DropdownContainer } from "./dropdown/DropdownContainer";
+
+export function FilterBar({
+  name,
+  optionTitle,
+  options,
+  value,
+}: {
+  name: string;
+  optionTitle: string;
+  options: {
+    name: string;
+    profile?: string;
+    selected: boolean;
+    onClick: () => void;
+  }[];
+  value: string;
+}) {
+  const [state, setState] = useState<"Enabled" | "Active">("Enabled");
+
+  const handleFilterBarFocus = () => {
+    setState("Active");
+  };
+
+  const handleFilterBarBlur = () => {
+    setState("Enabled");
+  };
+
+  return (
+    <Div
+      onFocus={handleFilterBarFocus}
+      onBlur={handleFilterBarBlur}
+      $state={state}
+    >
+      <DropdownContainer
+        name={name}
+        optionTitle={optionTitle}
+        options={options}
+        alignment="Left"
+      />
+      <TextInput size="S" icon="search" value={value} />
+    </Div>
+  );
+}
+
+const Div = styled.div<{ $state: "Enabled" | "Active" }>`
+  display: flex;
+  align-items: center;
+  gap: 1px;
+  width: 560px;
+  border: ${({ theme, $state }) =>
+    $state === "Active"
+      ? `${theme.border.default} ${theme.color.neutralBorderDefaultActive}`
+      : `${theme.border.default} ${theme.color.neutralBorderDefault}`};
+  border-radius: ${({ theme }) => theme.radius.medium};
+  background-color: ${({ theme }) => theme.color.neutralBorderDefault};
+
+  & > div:first-child {
+    border-radius: ${({ theme }) =>
+      `${theme.radius.medium} 0 0 ${theme.radius.medium}`};
+    background-color: ${({ theme, $state }) =>
+      $state === "Enabled"
+        ? theme.color.neutralSurfaceDefault
+        : theme.color.neutralSurfaceStrong};
+
+    & > button {
+      height: 40px;
+      padding: 0 24px;
+    }
+  }
+
+  & > div:last-child {
+    flex: 1;
+  }
+
+  & > div:last-child > div {
+    width: 100%;
+    border: none;
+    border-radius: ${({ theme }) =>
+      `0 ${theme.radius.medium} ${theme.radius.medium} 0`};
+    background-color: ${({ theme, $state }) =>
+      $state === "Enabled"
+        ? theme.color.neutralSurfaceBold
+        : theme.color.neutralSurfaceStrong};
+
+    & > input {
+      flex: 1;
+    }
+  }
+`;

--- a/frontend/src/components/TextInput.tsx
+++ b/frontend/src/components/TextInput.tsx
@@ -5,9 +5,10 @@ type TextInputProps = {
   width?: number;
   size: "L" | "S";
   value?: string;
-  label: string;
+  label?: string;
   caption?: string;
   disabled?: boolean;
+  icon?: string;
   validator?: (value: string) => boolean;
 };
 
@@ -30,6 +31,7 @@ export function TextInput({
   label,
   caption,
   disabled = false,
+  icon,
   validator,
 }: TextInputProps) {
   const [state, setState] = useState<TextInputState>(
@@ -62,7 +64,12 @@ export function TextInput({
   return (
     <Div $state={state}>
       <InputContainer $width={width} $size={size} $state={state}>
-        {inputValue && <StyledSpan>{label}</StyledSpan>}
+        {label && inputValue && <StyledSpan>{label}</StyledSpan>}
+        {icon && (
+          <IconWrapper>
+            <img src={`/src/assets/${icon}.svg`} />
+          </IconWrapper>
+        )}
         <Input
           placeholder={label}
           value={inputValue}
@@ -127,6 +134,13 @@ const StyledSpan = styled.span`
   width: 64px;
   color: ${({ theme }) => theme.color.neutralTextWeak};
   font: ${({ theme }) => theme.font.displayMedium12};
+`;
+
+const IconWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 32px;
 `;
 
 const Input = styled.input<InputProps>`

--- a/frontend/src/components/dropdown/DropdownIndicator.tsx
+++ b/frontend/src/components/dropdown/DropdownIndicator.tsx
@@ -23,7 +23,7 @@ const StyledButton = styled.button`
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 4px;
+  gap: 8px;
   height: 32px;
   border-radius: 20px;
   font: ${({ theme }) => theme.font.availableMedium16};

--- a/frontend/src/components/main/MainHeader.tsx
+++ b/frontend/src/components/main/MainHeader.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import { styled } from "styled-components";
 import { Button } from "../Button";
+import { FilterBar } from "../FilterBar";
 import { TabButton } from "../TabButton";
-import { DropdownContainer } from "../dropdown/DropdownContainer";
 import { SingleFilterData } from "./Main";
 
 type MainHeaderProps = {
@@ -53,15 +53,12 @@ export function MainHeader({
   return (
     <Div>
       <div>
-        <div style={{ display: "flex" }}>
-          <DropdownContainer
-            name="필터"
-            optionTitle={`이슈 필터`}
-            options={setDropdownOptions(singleFilters)}
-            alignment="Left"
-          />
-          <input />
-        </div>
+        <FilterBar
+          name="필터"
+          optionTitle={`이슈 필터`}
+          options={setDropdownOptions(singleFilters)}
+          value="is:issue is:open"
+        />
       </div>
       <div style={{ display: "flex", gap: "16px" }}>
         <TabButton onClick={onTabClick}>


### PR DESCRIPTION
## Description

- `FilterBar` 컴포넌트 구현 및 메인 페이지에 적용

## Key Changes

![image](https://github.com/masters2023-3rd-project-bugbusters/issue-tracker-max/assets/60080167/13da5c60-3e7c-49b0-a118-0a4048ea75d6)

- `Dropdown`, `TextInput` 컴포넌트를 재활용해서 `FilterBar` 구현

## To Reviewers

- 기존 스타일을 가진 컴포넌트를 사용해서 새로운 스타일의 컴포넌트를 만드려고 하니 styled component의 css 코드가 상당히 복잡해졌습니다.
- search 아이콘을 보이기 위해 `TextInput` 컴포넌트 코드에 약간의 수정이 이루어졌습니다.(props & return)

## Issues

- #53 

## Next Step

