### PR TITLE
[fe] TabButton Ghost 스타일 추가

### DIFF
--- a/frontend/src/components/TabButton.tsx
+++ b/frontend/src/components/TabButton.tsx
@@ -2,14 +2,19 @@ import { Children, ReactElement, cloneElement } from "react";
 import { styled } from "styled-components";
 
 export function TabButton({
+  type = "Outline",
   children,
   onClick,
 }: {
+  type?: "Ghost" | "Outline";
   children: ReactElement[];
   onClick: (name: string) => void;
 }) {
+  const TabButtonDiv =
+    type === "Ghost" ? GhostTabButtonDiv : OutlineTabButtonDiv;
+
   return (
-    <StyledTabButton>
+    <TabButtonDiv>
       {Children.map(children, (child) =>
         cloneElement(child, {
           onClick: () => {
@@ -17,19 +22,15 @@ export function TabButton({
           },
         }),
       )}
-    </StyledTabButton>
+    </TabButtonDiv>
   );
 }
 
-const StyledTabButton = styled.div`
+const BaseTabButtonDiv = styled.div`
   display: flex;
   align-items: center;
   width: fit-content;
   height: 40px;
-  border: ${({ theme }) =>
-    `${theme.border.default} ${theme.color.neutralBorderDefault}`};
-  border-radius: ${({ theme }) => theme.radius.medium};
-  background-color: ${({ theme }) => theme.color.neutralSurfaceDefault};
 
   & button {
     display: flex;
@@ -42,15 +43,34 @@ const StyledTabButton = styled.div`
         `${theme.radius.medium} 0 0 ${theme.radius.medium}`};
     }
 
+    &:last-child {
+      border-radius: ${({ theme }) =>
+        `0 ${theme.radius.medium} ${theme.radius.medium} 0`};
+    }
+  }
+`;
+
+const GhostTabButtonDiv = styled(BaseTabButtonDiv)`
+  border: none;
+  border-radius: 0;
+  background-color: transparent;
+
+  & button {
+    padding: 0 4px;
+  }
+`;
+
+const OutlineTabButtonDiv = styled(BaseTabButtonDiv)`
+  border: ${({ theme }) =>
+    `${theme.border.default} ${theme.color.neutralBorderDefault}`};
+  border-radius: ${({ theme }) => theme.radius.medium};
+  background-color: ${({ theme }) => theme.color.neutralSurfaceDefault};
+
+  & button {
     &:not(:last-child) {
       border-right: ${({ theme }) =>
         `${theme.border.default} ${theme.color.neutralBorderDefault}`};
       border-radius: 0;
-    }
-
-    &:last-child {
-      border-radius: ${({ theme }) =>
-        `0 ${theme.radius.medium} ${theme.radius.medium} 0`};
     }
 
     &.selected {

--- a/frontend/src/components/issue/IssueTableHeader.tsx
+++ b/frontend/src/components/issue/IssueTableHeader.tsx
@@ -38,7 +38,7 @@ export function IssueTableHeader({
       <CheckboxLabel>
         <input type="checkbox" />
       </CheckboxLabel>
-      <TabButton onClick={onIssueStateClick}>
+      <TabButton type="Ghost" onClick={onIssueStateClick}>
         {issueStates.map(({ name, icon, selected }, index) => (
           <Button
             key={`tab-${index}`}


### PR DESCRIPTION
## Description

- 이슈 상태 버튼(열린 이슈, 닫힌 이슈)에 적용할 스타일 추가

## Key Changes

![image](https://github.com/masters2023-3rd-project-bugbusters/issue-tracker-max/assets/60080167/761c68b0-a6df-442d-a041-bff2d04a1b90)

- `type` props 추가
- `type`에 따라 Ghost 스타일 또는 Outline 스타일 적용
- IssueTableHeader에 적용

## To Reviewers

- 버튼 사이 간격은 임의로 적용해놓은 상태입니다.

## Issues

- #18 

## Next Step

