### PR TITLE
[fe] textInput 기능, 옵션 추가

### DIFF
--- a/frontend/src/components/TextInput.tsx
+++ b/frontend/src/components/TextInput.tsx
@@ -5,11 +5,17 @@ type TextInputProps = {
   width?: number;
   size: "L" | "S";
   value?: string;
+  placeholder?: string;
   label?: string;
   caption?: string;
-  disabled?: boolean;
   icon?: string;
-  validator?: (value: string) => boolean;
+  fixLabel?: boolean;
+  borderNone?: boolean;
+  disabled?: boolean;
+  isError?: boolean;
+  onChange?: () => void;
+  onFocus?: () => void;
+  onBlur?: () => void;
 };
 
 type TextInputState = "Enabled" | "Active" | "Disabled" | "Error";
@@ -21,6 +27,7 @@ type InputProps = {
 type InputContainerProps = {
   $width: number;
   $size: "L" | "S";
+  $borderNone?: boolean;
   $state: TextInputState;
 };
 
@@ -29,10 +36,16 @@ export function TextInput({
   size,
   value: initialValue = "",
   label,
+  placeholder,
   caption,
-  disabled = false,
   icon,
-  validator,
+  fixLabel = false,
+  borderNone = false,
+  disabled = false,
+  isError = false,
+  onChange,
+  onFocus,
+  onBlur,
 }: TextInputProps) {
   const [state, setState] = useState<TextInputState>(
     disabled ? "Disabled" : "Enabled",
@@ -40,38 +53,48 @@ export function TextInput({
   const [inputValue, setInputValue] = useState(initialValue);
 
   useEffect(() => {
-    if (validator) {
-      setState(validator(inputValue) ? "Enabled" : "Error");
-    }
-  }, [inputValue, validator]);
+    setState(isError ? "Error" : "Enabled");
+  }, [inputValue, isError]);
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setInputValue(event.target.value);
+    const value = event.target.value;
+
+    setInputValue(value);
+    onChange && onChange();
   };
 
   const handleInputFocus = () => {
     if (state !== "Error") {
       setState("Active");
     }
+
+    onFocus && onFocus();
   };
 
   const handleInputBlur = () => {
     if (state !== "Error") {
       setState(disabled ? "Disabled" : "Enabled");
     }
+
+    onBlur && onBlur();
   };
 
   return (
     <Div $state={state}>
-      <InputContainer $width={width} $size={size} $state={state}>
-        {label && inputValue && <StyledSpan>{label}</StyledSpan>}
+      <InputContainer
+        $width={width}
+        $size={size}
+        $state={state}
+        $borderNone={borderNone}
+      >
+        {(fixLabel || inputValue) && label && <StyledSpan>{label}</StyledSpan>}
         {icon && (
           <IconWrapper>
             <img src={`/src/assets/${icon}.svg`} />
           </IconWrapper>
         )}
         <Input
-          placeholder={label}
+          placeholder={placeholder}
           value={inputValue}
           onChange={handleInputChange}
           onFocus={handleInputFocus}
@@ -118,14 +141,17 @@ const InputContainer = styled.div<InputContainerProps>`
         return theme.color.neutralSurfaceBold;
     }
   }};
-  border: ${({ theme, $state }) => {
+  border: ${({ theme, $state, $borderNone }) => {
+    if ($borderNone) {
+      return "none";
+    }
     switch ($state) {
       case "Active":
         return `1px solid ${theme.color.neutralBorderDefaultActive}`;
       case "Error":
         return `1px solid ${theme.color.dangerBorderDefault}`;
       default:
-        return "";
+        return "none";
     }
   }};
 `;


### PR DESCRIPTION
## Description
- 피그마에 있는 공용 컴포넌트 디자인 외 필요한 옵션, 기능을 추가했습니다.

## Key Changes
-  다음 props들이 추가/수정되었습니다.
   - **isError?: boolean;**
     - 정규식 함수를 받던 validator를 isError로 변경합니다.
   - **placeholder?: string;**
     - 원래 label의 값을 placeholder로도 함께 사용하고 있었지만 추가로 받기로 했습니다.
   - **fixLabel?: boolean;**
     - input의 value에 상관 없이 항상 label을 고정 시킵니다
   - **borderNone?: boolean;**
     - border가 필요 없을 경우 사용합니다.
   - **onChange?: () => void;**
   - **onFocus?: () => void;**
   - **onBlur?: () => void;**
     - 위 3개의 함수는 외부에서 input의 상태/값에 따라 관리하기 위해 추가된 함수입니다. 
## To Reviewers
- label 작업중 texInput이 생각 이상의 기능을 해야 하고 값을 외부에서 관리해야 해서 수정을 하기로 했습니다.
- FilterBar 부분도 어짜피 수정하기로 했기 때문에 조금 고려해서 옵션과 함수를 추가해 봤습니다.
- 하지만 props가 너무 많아지고 component가 너무 커진 느낌이 있습니다.
- 다음은 사용 예시 입니다.
``` ts
function TextInputTest() {
  const [isFocus, setIsFocus] = useState(false);

  const onFocus = () => {
    setIsFocus(true);
  };

  const onBlur = () => {
    setIsFocus(false);
  };

  return (
    <div style={{ background: isFocus ? "red" : "transparent" }}>
      <TextInput
        size="S"
        label="아이디"
        fixLabel
        borderNone
        placeholder="test Placeholder"
        value="Test"
        onFocus={onFocus}
        onBlur={onBlur}
      />
    </div>
  );
}
```

## Issue
- #65 