### PR TITLE
[be] 댓글 수정 API 구현

### DIFF
--- a/backend/src/main/java/codesquard/app/comment/controller/CommentController.java
+++ b/backend/src/main/java/codesquard/app/comment/controller/CommentController.java
@@ -6,12 +6,16 @@ import javax.validation.Valid;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import codesquard.app.comment.controller.request.CommentModifyRequest;
 import codesquard.app.comment.controller.request.CommentSaveRequest;
 import codesquard.app.comment.service.CommentService;
+import codesquard.app.comment.service.response.CommentModifyResponse;
 import codesquard.app.comment.service.response.CommentSaveResponse;
 import lombok.RequiredArgsConstructor;
 
@@ -26,6 +30,14 @@ public class CommentController {
 		LocalDateTime createdAt = LocalDateTime.now();
 		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(commentService.save(request.toServiceRequest(), createdAt));
+	}
+
+	@PatchMapping("/api/comments/{id}")
+	public ResponseEntity<CommentModifyResponse> modifyComment(@Valid @RequestBody CommentModifyRequest request,
+		@PathVariable Long id) {
+		LocalDateTime modifiedAt = LocalDateTime.now();
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(commentService.modify(request.toServiceRequest(id), modifiedAt));
 	}
 
 }

--- a/backend/src/main/java/codesquard/app/comment/controller/request/CommentModifyRequest.java
+++ b/backend/src/main/java/codesquard/app/comment/controller/request/CommentModifyRequest.java
@@ -1,0 +1,24 @@
+package codesquard.app.comment.controller.request;
+
+import javax.validation.constraints.NotBlank;
+
+import codesquard.app.comment.service.request.CommentModifyServiceRequest;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentModifyRequest {
+
+	@NotBlank(message = "내용은 필수입니다.")
+	private String content;
+
+	public CommentModifyServiceRequest toServiceRequest(Long id) {
+		return new CommentModifyServiceRequest(id, content);
+	}
+
+	public String getContent() {
+		return content;
+	}
+
+}

--- a/backend/src/main/java/codesquard/app/comment/controller/request/CommentModifyRequest.java
+++ b/backend/src/main/java/codesquard/app/comment/controller/request/CommentModifyRequest.java
@@ -3,10 +3,11 @@ package codesquard.app.comment.controller.request;
 import javax.validation.constraints.NotBlank;
 
 import codesquard.app.comment.service.request.CommentModifyServiceRequest;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class CommentModifyRequest {
 

--- a/backend/src/main/java/codesquard/app/comment/controller/request/CommentSaveRequest.java
+++ b/backend/src/main/java/codesquard/app/comment/controller/request/CommentSaveRequest.java
@@ -4,10 +4,11 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 import codesquard.app.comment.service.request.CommentSaveServiceRequest;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class CommentSaveRequest {
 

--- a/backend/src/main/java/codesquard/app/comment/controller/request/CommentSaveRequest.java
+++ b/backend/src/main/java/codesquard/app/comment/controller/request/CommentSaveRequest.java
@@ -4,19 +4,21 @@ import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 import codesquard.app.comment.service.request.CommentSaveServiceRequest;
-import lombok.RequiredArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 
-@RequiredArgsConstructor
+@NoArgsConstructor
+@AllArgsConstructor
 public class CommentSaveRequest {
 
 	@NotNull(message = "이슈 아이디는 필수입니다.")
-	private final Long issueId;
+	private Long issueId;
 
 	@NotNull(message = "사용자 아이디는 필수입니다.")
-	private final Long userId;
+	private Long userId;
 
 	@NotBlank(message = "내용은 필수입니다.")
-	private final String content;
+	private String content;
 
 	public CommentSaveServiceRequest toServiceRequest() {
 		return new CommentSaveServiceRequest(issueId, userId, content);

--- a/backend/src/main/java/codesquard/app/comment/entity/Comment.java
+++ b/backend/src/main/java/codesquard/app/comment/entity/Comment.java
@@ -19,6 +19,16 @@ public class Comment {
 		this.createdAt = createdAt;
 	}
 
+	public Comment(Long id, String content, LocalDateTime modifiedAt) {
+		this.id = id;
+		this.content = content;
+		this.modifiedAt = modifiedAt;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
 	public Long getIssueId() {
 		return issueId;
 	}
@@ -33,6 +43,10 @@ public class Comment {
 
 	public LocalDateTime getCreatedAt() {
 		return createdAt;
+	}
+
+	public LocalDateTime getModifiedAt() {
+		return modifiedAt;
 	}
 
 }

--- a/backend/src/main/java/codesquard/app/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/codesquard/app/comment/repository/CommentRepository.java
@@ -1,6 +1,5 @@
 package codesquard.app.comment.repository;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -44,10 +43,11 @@ public class CommentRepository {
 		return null;
 	}
 
-	public Long modify(Long id, String content, LocalDateTime modifiedAt) {
+	public Long modify(Comment comment) {
 		String sql = "UPDATE comment SET content = :content, modified_at = :modifiedAt WHERE id = :id";
-		template.update(sql, Map.of("id", id, "content", content, "modifiedAt", modifiedAt));
-		return id;
+		template.update(sql,
+			Map.of("id", comment.getId(), "content", comment.getContent(), "modifiedAt", comment.getModifiedAt()));
+		return comment.getId();
 	}
 
 	public Long deleteById(Long id) {

--- a/backend/src/main/java/codesquard/app/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/codesquard/app/comment/repository/CommentRepository.java
@@ -1,6 +1,8 @@
 package codesquard.app.comment.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -42,8 +44,10 @@ public class CommentRepository {
 		return null;
 	}
 
-	public Long modifyById(Comment comment) {
-		return null;
+	public Long modify(Long id, String content, LocalDateTime modifiedAt) {
+		String sql = "UPDATE comment SET content = :content, modified_at = :modifiedAt WHERE id = :id";
+		template.update(sql, Map.of("id", id, "content", content, "modifiedAt", modifiedAt));
+		return id;
 	}
 
 	public Long deleteById(Long id) {

--- a/backend/src/main/java/codesquard/app/comment/service/CommentService.java
+++ b/backend/src/main/java/codesquard/app/comment/service/CommentService.java
@@ -7,7 +7,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import codesquard.app.comment.entity.Comment;
 import codesquard.app.comment.repository.CommentRepository;
+import codesquard.app.comment.service.request.CommentModifyServiceRequest;
 import codesquard.app.comment.service.request.CommentSaveServiceRequest;
+import codesquard.app.comment.service.response.CommentModifyResponse;
 import codesquard.app.comment.service.response.CommentSaveResponse;
 import lombok.RequiredArgsConstructor;
 
@@ -24,6 +26,14 @@ public class CommentService {
 		Long savedCommentId = commentRepository.save(comment);
 
 		return new CommentSaveResponse(true, savedCommentId);
+	}
+
+	@Transactional
+	public CommentModifyResponse modify(CommentModifyServiceRequest serviceRequest, LocalDateTime modifiedAt) {
+		Comment comment = serviceRequest.toEntity(modifiedAt);
+		Long modifiedCommentId = commentRepository.modify(comment);
+
+		return new CommentModifyResponse(true, modifiedCommentId);
 	}
 
 }

--- a/backend/src/main/java/codesquard/app/comment/service/request/CommentModifyServiceRequest.java
+++ b/backend/src/main/java/codesquard/app/comment/service/request/CommentModifyServiceRequest.java
@@ -1,0 +1,36 @@
+package codesquard.app.comment.service.request;
+
+import java.time.LocalDateTime;
+
+import codesquard.app.comment.entity.Comment;
+import codesquard.app.errors.exception.CommentMaxLengthExceededException;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentModifyServiceRequest {
+
+	private Long id;
+	private String content;
+
+	private void validateContentLength(String content) {
+		if (content.length() > 10000) {
+			throw new CommentMaxLengthExceededException();
+		}
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public String getContent() {
+		return content;
+	}
+
+	public Comment toEntity(LocalDateTime modifiedAt) {
+		validateContentLength(this.content);
+		return new Comment(id, content, modifiedAt);
+	}
+
+}

--- a/backend/src/main/java/codesquard/app/comment/service/request/CommentModifyServiceRequest.java
+++ b/backend/src/main/java/codesquard/app/comment/service/request/CommentModifyServiceRequest.java
@@ -4,10 +4,11 @@ import java.time.LocalDateTime;
 
 import codesquard.app.comment.entity.Comment;
 import codesquard.app.errors.exception.CommentMaxLengthExceededException;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class CommentModifyServiceRequest {
 

--- a/backend/src/main/java/codesquard/app/comment/service/request/CommentSaveServiceRequest.java
+++ b/backend/src/main/java/codesquard/app/comment/service/request/CommentSaveServiceRequest.java
@@ -4,10 +4,11 @@ import java.time.LocalDateTime;
 
 import codesquard.app.comment.entity.Comment;
 import codesquard.app.errors.exception.CommentMaxLengthExceededException;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class CommentSaveServiceRequest {
 

--- a/backend/src/main/java/codesquard/app/comment/service/request/CommentSaveServiceRequest.java
+++ b/backend/src/main/java/codesquard/app/comment/service/request/CommentSaveServiceRequest.java
@@ -4,16 +4,18 @@ import java.time.LocalDateTime;
 
 import codesquard.app.comment.entity.Comment;
 import codesquard.app.errors.exception.CommentMaxLengthExceededException;
-import lombok.RequiredArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 
-@RequiredArgsConstructor
+@NoArgsConstructor
+@AllArgsConstructor
 public class CommentSaveServiceRequest {
 
-	private final Long issueId;
+	private Long issueId;
 
-	private final Long userId;
+	private Long userId;
 
-	private final String content;
+	private String content;
 
 	public Comment toEntity(LocalDateTime createdAt) {
 		validateContentLength(this.content);

--- a/backend/src/main/java/codesquard/app/comment/service/response/CommentModifyResponse.java
+++ b/backend/src/main/java/codesquard/app/comment/service/response/CommentModifyResponse.java
@@ -1,17 +1,13 @@
 package codesquard.app.comment.service.response;
 
-public class CommentSaveResponse {
+public class CommentModifyResponse {
 
 	private final boolean success;
 	private final Long commentId;
 
-	public CommentSaveResponse(boolean success, Long commentId) {
+	public CommentModifyResponse(boolean success, Long commentId) {
 		this.success = success;
 		this.commentId = commentId;
-	}
-
-	public Long getCommentId() {
-		return commentId;
 	}
 
 }

--- a/backend/src/main/java/codesquard/app/comment/service/response/CommentModifyResponse.java
+++ b/backend/src/main/java/codesquard/app/comment/service/response/CommentModifyResponse.java
@@ -1,13 +1,22 @@
 package codesquard.app.comment.service.response;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class CommentModifyResponse {
 
-	private final boolean success;
-	private final Long commentId;
+	private boolean success;
+	private Long commentId;
 
-	public CommentModifyResponse(boolean success, Long commentId) {
-		this.success = success;
-		this.commentId = commentId;
+	public boolean isSuccess() {
+		return success;
+	}
+
+	public Long getCommentId() {
+		return commentId;
 	}
 
 }

--- a/backend/src/main/java/codesquard/app/comment/service/response/CommentSaveResponse.java
+++ b/backend/src/main/java/codesquard/app/comment/service/response/CommentSaveResponse.java
@@ -1,17 +1,22 @@
 package codesquard.app.comment.service.response;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class CommentSaveResponse {
 
-	private final boolean success;
-	private final Long commentId;
-
-	public CommentSaveResponse(boolean success, Long commentId) {
-		this.success = success;
-		this.commentId = commentId;
-	}
+	private boolean success;
+	private Long commentId;
 
 	public Long getCommentId() {
 		return commentId;
+	}
+
+	public boolean isSuccess() {
+		return success;
 	}
 
 }

--- a/backend/src/test/java/codesquard/app/comment/controller/CommentControllerTest.java
+++ b/backend/src/test/java/codesquard/app/comment/controller/CommentControllerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.MediaType;
 
 import codesquard.app.ControllerTestSupport;
+import codesquard.app.comment.controller.request.CommentModifyRequest;
 import codesquard.app.comment.controller.request.CommentSaveRequest;
 
 class CommentControllerTest extends ControllerTestSupport {
@@ -49,6 +50,36 @@ class CommentControllerTest extends ControllerTestSupport {
 
 		// when // then
 		mockMvc.perform(post("/api/comments")
+				.content(objectMapper.writeValueAsString(request))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.content").value("내용은 필수입니다."));
+	}
+
+	@DisplayName("등록된 댓글을 수정한다.")
+	@Test
+	void modify() throws Exception {
+		// given
+		CommentModifyRequest request = new CommentModifyRequest("controller comment");
+
+		// when // then
+		mockMvc.perform(patch("/api/comments/1")
+				.content(objectMapper.writeValueAsString(request))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andDo(print())
+			.andExpect(status().isOk());
+	}
+
+	@DisplayName("댓글 수정 시 내용이 비어있는 경우 예외가 발생한다.")
+	@MethodSource("provideInvalidContent")
+	@ParameterizedTest
+	void modifyInvalidComment(String content) throws Exception {
+		// given
+		CommentModifyRequest request = new CommentModifyRequest(content);
+
+		// when // then
+		mockMvc.perform(patch("/api/comments/1")
 				.content(objectMapper.writeValueAsString(request))
 				.contentType(MediaType.APPLICATION_JSON))
 			.andDo(print())

--- a/backend/src/test/java/codesquard/app/comment/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/codesquard/app/comment/repository/CommentRepositoryTest.java
@@ -60,6 +60,26 @@ class CommentRepositoryTest extends IntegrationTestSupport {
 		assertThat(savedCommentId).isEqualTo(1L);
 	}
 
+	@DisplayName("등록된 댓글을 수정한다.")
+	@Test
+	void modify() {
+		// given
+		LocalDateTime createdAt = LocalDateTime.of(2023, 8, 1, 16, 0);
+		LocalDateTime modifiedAt = LocalDateTime.of(2023, 8, 1, 17, 0);
+
+		createUser("yeon", "yeon@email.com", "password1000", "url path");
+		createIssue(null, 1L, "test issue", "hello", IssueStatus.OPENED, createdAt);
+
+		Comment comment = new Comment(1L, 1L, "Create New Comment", createdAt);
+		Long savedCommentId = commentRepository.save(comment);
+
+		// when
+		Long modifiedCommentId = commentRepository.modify(savedCommentId, "modified repository content", modifiedAt);
+
+		// then
+		assertThat(modifiedCommentId).isEqualTo(savedCommentId);
+	}
+
 	private void createUser(String loginId, String email, String password, String avatarUrl) {
 		User user = new User(loginId, email, password, avatarUrl);
 		userRepository.save(user);

--- a/backend/src/test/java/codesquard/app/comment/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/codesquard/app/comment/repository/CommentRepositoryTest.java
@@ -73,8 +73,10 @@ class CommentRepositoryTest extends IntegrationTestSupport {
 		Comment comment = new Comment(1L, 1L, "Create New Comment", createdAt);
 		Long savedCommentId = commentRepository.save(comment);
 
+		Comment commentForModify = new Comment(savedCommentId, "modified repository content", modifiedAt);
+
 		// when
-		Long modifiedCommentId = commentRepository.modify(savedCommentId, "modified repository content", modifiedAt);
+		Long modifiedCommentId = commentRepository.modify(commentForModify);
 
 		// then
 		assertThat(modifiedCommentId).isEqualTo(savedCommentId);


### PR DESCRIPTION
## Description

댓글 수정 API 1차 구현을 완료했습니다.

- 로그인한 회원인지 검증하지 않습니다.
- 자신이 작성한 댓글인지 검증하지 않습니다.
- 존재하는 댓글인지 확인하지 않습니다.

위 검증 로직은 추후 회원 기능이 구현되면 추가하겠습니다.

## Next Step

댓글 삭제 API 구현 예정입니다.
