### PR TITLE
[be] 마일스톤 READ API, 상태 수정 구현

### DIFF
--- a/backend/src/main/java/codesquard/app/label/controller/LabelController.java
+++ b/backend/src/main/java/codesquard/app/label/controller/LabelController.java
@@ -17,7 +17,6 @@ import codesquard.app.label.dto.LabelSaveResponse;
 import codesquard.app.label.dto.LabelUpdateRequest;
 import codesquard.app.label.dto.LabelUpdateResponse;
 import codesquard.app.label.service.LabelService;
-import codesquard.app.milestone.dto.request.MilestoneUpdateRequest;
 
 @RestController
 public class LabelController {

--- a/backend/src/main/java/codesquard/app/milestone/controller/MilestoneController.java
+++ b/backend/src/main/java/codesquard/app/milestone/controller/MilestoneController.java
@@ -5,18 +5,24 @@ import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import codesquard.app.milestone.dto.request.MilestoneSaveRequest;
+import codesquard.app.milestone.dto.request.MilestoneStatusRequest;
 import codesquard.app.milestone.dto.request.MilestoneUpdateRequest;
 import codesquard.app.milestone.dto.response.MilestoneDeleteResponse;
+import codesquard.app.milestone.dto.response.MilestoneReadResponse;
 import codesquard.app.milestone.dto.response.MilestoneSaveResponse;
+import codesquard.app.milestone.dto.response.MilestoneStatusUpdateResponse;
 import codesquard.app.milestone.dto.response.MilestoneUpdateResponse;
-import codesquard.app.milestone.dto.response.MilestoneSaveResponse;
+import codesquard.app.milestone.entity.MilestoneStatus;
 import codesquard.app.milestone.service.MilestoneService;
 
 @RestController
@@ -27,11 +33,34 @@ public class MilestoneController {
 		this.milestoneService = milestoneService;
 	}
 
+	@GetMapping("/api/milestones")
+	public ResponseEntity<MilestoneReadResponse> getOpened(
+		@RequestParam(name = "state", defaultValue = "opened") String openedString,
+		@RequestParam(name = "state", defaultValue = "closed") String closedString) {
+		MilestoneReadResponse milestoneReadResponse = milestoneService.makeMilestoneResponse(
+			chooseStatus(closedString));
+
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(milestoneReadResponse.success());
+	}
+
+	/**
+	 * closed로 받아온 값이 closed가 아니라면 무조건 opened라는 의미이므로
+	 * 사실상 매개변수에 opened를 추가할 필요는 없음
+	 */
+	private MilestoneStatus chooseStatus(String closedString) {
+		if (closedString.equalsIgnoreCase("closed")) {
+			return MilestoneStatus.CLOSED;
+		}
+
+		return MilestoneStatus.OPENED;
+	}
+
 	@PostMapping("/api/milestones")
 	public ResponseEntity<MilestoneSaveResponse> save(@Valid @RequestBody MilestoneSaveRequest milestoneSaveRequest) {
 		Long milestoneId = milestoneService.saveMilestone(milestoneSaveRequest);
 		return ResponseEntity.status(HttpStatus.CREATED)
-			.body(MilestoneSaveResponse.success(true, milestoneId));
+			.body(MilestoneSaveResponse.success(milestoneId));
 	}
 
 	@PutMapping("/api/milestones/{milestoneId}")
@@ -40,7 +69,16 @@ public class MilestoneController {
 		milestoneService.updateMilestone(milestoneId, milestoneUpdateRequest);
 
 		return ResponseEntity.status(HttpStatus.OK)
-			.body(MilestoneUpdateResponse.success(true));
+			.body(MilestoneUpdateResponse.success());
+	}
+
+	@PatchMapping("/api/milestones/{milestoneId}/status")
+	public ResponseEntity<MilestoneStatusUpdateResponse> updateStatus(@PathVariable final Long milestoneId,
+		@Valid @RequestBody MilestoneStatusRequest milestoneStatusRequest) {
+		milestoneService.updateMilestoneStatus(milestoneId, milestoneStatusRequest);
+
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(MilestoneStatusUpdateResponse.success());
 	}
 
 	@DeleteMapping("/api/milestones/{milestoneId}")
@@ -48,6 +86,6 @@ public class MilestoneController {
 		milestoneService.deleteMilestone(milestoneId);
 
 		return ResponseEntity.status(HttpStatus.OK)
-			.body(MilestoneDeleteResponse.success(true));
+			.body(MilestoneDeleteResponse.success());
 	}
 }

--- a/backend/src/main/java/codesquard/app/milestone/controller/MilestoneController.java
+++ b/backend/src/main/java/codesquard/app/milestone/controller/MilestoneController.java
@@ -38,17 +38,17 @@ public class MilestoneController {
 		@RequestParam(name = "state", defaultValue = "opened") String openedString,
 		@RequestParam(name = "state", defaultValue = "closed") String closedString) {
 		MilestoneReadResponse milestoneReadResponse = milestoneService.makeMilestoneResponse(
-			chooseStatus(closedString));
+			chooseStatus(openedString, closedString));
 
 		return ResponseEntity.status(HttpStatus.OK)
 			.body(milestoneReadResponse.success());
 	}
 
-	/**
-	 * closed로 받아온 값이 closed가 아니라면 무조건 opened라는 의미이므로
-	 * 사실상 매개변수에 opened를 추가할 필요는 없음
-	 */
-	private MilestoneStatus chooseStatus(String closedString) {
+	private MilestoneStatus chooseStatus(String openedString, String closedString) {
+		if (openedString.equalsIgnoreCase("opened")) {
+			return MilestoneStatus.OPENED;
+		}
+
 		if (closedString.equalsIgnoreCase("closed")) {
 			return MilestoneStatus.CLOSED;
 		}

--- a/backend/src/main/java/codesquard/app/milestone/dto/request/MilestoneSaveRequest.java
+++ b/backend/src/main/java/codesquard/app/milestone/dto/request/MilestoneSaveRequest.java
@@ -5,14 +5,19 @@ import java.time.LocalDate;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import codesquard.app.milestone.entity.Milestone;
 
 public class MilestoneSaveRequest {
 	@NotNull(message = "제목 입력은 필수입니다.")
 	@Size(min = 1, max = 50, message = "제목은 1글자 이상, 50글자 이하여야 합니다.")
+	@JsonProperty("name")
 	private String name;
+	@JsonProperty("deadline")
 	private LocalDate deadline;
 	@Size(min = 1, max = 10000, message = "내용은 1글자 이상, 10000글자 이하여야 합니다.")
+	@JsonProperty("description")
 	private String description;
 
 	private MilestoneSaveRequest() {
@@ -27,17 +32,5 @@ public class MilestoneSaveRequest {
 	public static Milestone toEntity(MilestoneSaveRequest milestoneSaveRequest) {
 		return new Milestone(milestoneSaveRequest.name, milestoneSaveRequest.description,
 			milestoneSaveRequest.deadline);
-	}
-
-	public String getName() {
-		return name;
-	}
-
-	public LocalDate getDeadline() {
-		return deadline;
-	}
-
-	public String getDescription() {
-		return description;
 	}
 }

--- a/backend/src/main/java/codesquard/app/milestone/dto/request/MilestoneStatusRequest.java
+++ b/backend/src/main/java/codesquard/app/milestone/dto/request/MilestoneStatusRequest.java
@@ -1,0 +1,26 @@
+package codesquard.app.milestone.dto.request;
+
+import codesquard.app.milestone.entity.MilestoneStatus;
+
+public class MilestoneStatusRequest {
+	private String status;
+
+	private MilestoneStatusRequest() {
+	}
+
+	public MilestoneStatusRequest(String status) {
+		this.status = status;
+	}
+
+	public static MilestoneStatus toStatus(MilestoneStatusRequest milestoneStatusRequest) {
+		if (milestoneStatusRequest.status.equalsIgnoreCase("OPENED")) {
+			return MilestoneStatus.OPENED;
+		}
+
+		return MilestoneStatus.CLOSED;
+	}
+
+	public String getStatus() {
+		return status;
+	}
+}

--- a/backend/src/main/java/codesquard/app/milestone/dto/request/MilestoneStatusRequest.java
+++ b/backend/src/main/java/codesquard/app/milestone/dto/request/MilestoneStatusRequest.java
@@ -1,14 +1,14 @@
 package codesquard.app.milestone.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import codesquard.app.milestone.entity.MilestoneStatus;
 
 public class MilestoneStatusRequest {
+	@JsonProperty("status")
 	private String status;
 
-	private MilestoneStatusRequest() {
-	}
-
-	public MilestoneStatusRequest(String status) {
+	private MilestoneStatusRequest(String status) {
 		this.status = status;
 	}
 
@@ -18,9 +18,5 @@ public class MilestoneStatusRequest {
 		}
 
 		return MilestoneStatus.CLOSED;
-	}
-
-	public String getStatus() {
-		return status;
 	}
 }

--- a/backend/src/main/java/codesquard/app/milestone/dto/request/MilestoneUpdateRequest.java
+++ b/backend/src/main/java/codesquard/app/milestone/dto/request/MilestoneUpdateRequest.java
@@ -18,14 +18,15 @@ public class MilestoneUpdateRequest {
 	private MilestoneUpdateRequest() {
 	}
 
-	public MilestoneUpdateRequest(String name, LocalDate deadline, String description) {
+	private MilestoneUpdateRequest(String name, LocalDate deadline, String description) {
 		this.name = name;
 		this.deadline = deadline;
 		this.description = description;
 	}
 
 	public static Milestone toEntity(MilestoneUpdateRequest milestoneUpdateRequest) {
-		return new Milestone(milestoneUpdateRequest.name, milestoneUpdateRequest.description, milestoneUpdateRequest.deadline);
+		return new Milestone(milestoneUpdateRequest.name, milestoneUpdateRequest.description,
+			milestoneUpdateRequest.deadline);
 	}
 
 	public String getName() {

--- a/backend/src/main/java/codesquard/app/milestone/dto/request/MilestoneUpdateRequest.java
+++ b/backend/src/main/java/codesquard/app/milestone/dto/request/MilestoneUpdateRequest.java
@@ -5,14 +5,19 @@ import java.time.LocalDate;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import codesquard.app.milestone.entity.Milestone;
 
 public class MilestoneUpdateRequest {
 	@NotNull(message = "제목 입력은 필수입니다.")
 	@Size(min = 1, max = 50, message = "제목은 1글자 이상, 50글자 이하여야 합니다.")
+	@JsonProperty("name")
 	private String name;
+	@JsonProperty("deadline")
 	private LocalDate deadline;
 	@Size(min = 1, max = 10000, message = "내용은 1글자 이상, 10000글자 이하여야 합니다.")
+	@JsonProperty("description")
 	private String description;
 
 	private MilestoneUpdateRequest() {
@@ -27,17 +32,5 @@ public class MilestoneUpdateRequest {
 	public static Milestone toEntity(MilestoneUpdateRequest milestoneUpdateRequest) {
 		return new Milestone(milestoneUpdateRequest.name, milestoneUpdateRequest.description,
 			milestoneUpdateRequest.deadline);
-	}
-
-	public String getName() {
-		return name;
-	}
-
-	public LocalDate getDeadline() {
-		return deadline;
-	}
-
-	public String getDescription() {
-		return description;
 	}
 }

--- a/backend/src/main/java/codesquard/app/milestone/dto/response/MilestoneDeleteResponse.java
+++ b/backend/src/main/java/codesquard/app/milestone/dto/response/MilestoneDeleteResponse.java
@@ -1,6 +1,9 @@
 package codesquard.app.milestone.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class MilestoneDeleteResponse {
+	@JsonProperty("success")
 	private final boolean success;
 
 	private MilestoneDeleteResponse(boolean success) {
@@ -9,9 +12,5 @@ public class MilestoneDeleteResponse {
 
 	public static MilestoneDeleteResponse success() {
 		return new MilestoneDeleteResponse(true);
-	}
-
-	public boolean isSuccess() {
-		return success;
 	}
 }

--- a/backend/src/main/java/codesquard/app/milestone/dto/response/MilestoneDeleteResponse.java
+++ b/backend/src/main/java/codesquard/app/milestone/dto/response/MilestoneDeleteResponse.java
@@ -7,8 +7,8 @@ public class MilestoneDeleteResponse {
 		this.success = success;
 	}
 
-	public static MilestoneDeleteResponse success(boolean success) {
-		return new MilestoneDeleteResponse(success);
+	public static MilestoneDeleteResponse success() {
+		return new MilestoneDeleteResponse(true);
 	}
 
 	public boolean isSuccess() {

--- a/backend/src/main/java/codesquard/app/milestone/dto/response/MilestoneReadResponse.java
+++ b/backend/src/main/java/codesquard/app/milestone/dto/response/MilestoneReadResponse.java
@@ -1,0 +1,38 @@
+package codesquard.app.milestone.dto.response;
+
+import java.util.List;
+
+public class MilestoneReadResponse {
+	private Long openedMilestoneCount;
+	private Long closedMilestoneCount;
+	private Long labelCount;
+	private List<MilestonesResponse> milestones;
+
+	public MilestoneReadResponse(Long openedMilestoneCount, Long closedMilestoneCount, Long labelCount,
+		List<MilestonesResponse> milestones) {
+		this.openedMilestoneCount = openedMilestoneCount;
+		this.closedMilestoneCount = closedMilestoneCount;
+		this.labelCount = labelCount;
+		this.milestones = milestones;
+	}
+
+	public MilestoneReadResponse success() {
+		return new MilestoneReadResponse(openedMilestoneCount, closedMilestoneCount, labelCount, milestones);
+	}
+
+	public Long getOpenedMilestoneCount() {
+		return openedMilestoneCount;
+	}
+
+	public Long getClosedMilestoneCount() {
+		return closedMilestoneCount;
+	}
+
+	public Long getLabelCount() {
+		return labelCount;
+	}
+
+	public List<MilestonesResponse> getMilestones() {
+		return milestones;
+	}
+}

--- a/backend/src/main/java/codesquard/app/milestone/dto/response/MilestoneReadResponse.java
+++ b/backend/src/main/java/codesquard/app/milestone/dto/response/MilestoneReadResponse.java
@@ -2,10 +2,16 @@ package codesquard.app.milestone.dto.response;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class MilestoneReadResponse {
+	@JsonProperty("openedMilestoneCount")
 	private Long openedMilestoneCount;
+	@JsonProperty("closedMilestoneCount")
 	private Long closedMilestoneCount;
+	@JsonProperty("labelCount")
 	private Long labelCount;
+	@JsonProperty("milestones")
 	private List<MilestonesResponse> milestones;
 
 	public MilestoneReadResponse(Long openedMilestoneCount, Long closedMilestoneCount, Long labelCount,
@@ -18,21 +24,5 @@ public class MilestoneReadResponse {
 
 	public MilestoneReadResponse success() {
 		return new MilestoneReadResponse(openedMilestoneCount, closedMilestoneCount, labelCount, milestones);
-	}
-
-	public Long getOpenedMilestoneCount() {
-		return openedMilestoneCount;
-	}
-
-	public Long getClosedMilestoneCount() {
-		return closedMilestoneCount;
-	}
-
-	public Long getLabelCount() {
-		return labelCount;
-	}
-
-	public List<MilestonesResponse> getMilestones() {
-		return milestones;
 	}
 }

--- a/backend/src/main/java/codesquard/app/milestone/dto/response/MilestoneSaveResponse.java
+++ b/backend/src/main/java/codesquard/app/milestone/dto/response/MilestoneSaveResponse.java
@@ -9,8 +9,8 @@ public class MilestoneSaveResponse {
 		this.id = id;
 	}
 
-	public static MilestoneSaveResponse success(boolean success, Long id) {
-		return new MilestoneSaveResponse(success, id);
+	public static MilestoneSaveResponse success(Long id) {
+		return new MilestoneSaveResponse(true, id);
 	}
 
 	public boolean isSuccess() {

--- a/backend/src/main/java/codesquard/app/milestone/dto/response/MilestoneSaveResponse.java
+++ b/backend/src/main/java/codesquard/app/milestone/dto/response/MilestoneSaveResponse.java
@@ -1,7 +1,11 @@
 package codesquard.app.milestone.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class MilestoneSaveResponse {
+	@JsonProperty("success")
 	private final boolean success;
+	@JsonProperty("id")
 	private final Long id;
 
 	private MilestoneSaveResponse(boolean success, Long id) {
@@ -11,13 +15,5 @@ public class MilestoneSaveResponse {
 
 	public static MilestoneSaveResponse success(Long id) {
 		return new MilestoneSaveResponse(true, id);
-	}
-
-	public boolean isSuccess() {
-		return success;
-	}
-
-	public Long getId() {
-		return id;
 	}
 }

--- a/backend/src/main/java/codesquard/app/milestone/dto/response/MilestoneStatusUpdateResponse.java
+++ b/backend/src/main/java/codesquard/app/milestone/dto/response/MilestoneStatusUpdateResponse.java
@@ -1,0 +1,17 @@
+package codesquard.app.milestone.dto.response;
+
+public class MilestoneStatusUpdateResponse {
+	private final boolean success;
+
+	private MilestoneStatusUpdateResponse(boolean success) {
+		this.success = success;
+	}
+
+	public static MilestoneStatusUpdateResponse success() {
+		return new MilestoneStatusUpdateResponse(true);
+	}
+
+	public boolean isSuccess() {
+		return success;
+	}
+}

--- a/backend/src/main/java/codesquard/app/milestone/dto/response/MilestoneStatusUpdateResponse.java
+++ b/backend/src/main/java/codesquard/app/milestone/dto/response/MilestoneStatusUpdateResponse.java
@@ -1,6 +1,9 @@
 package codesquard.app.milestone.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class MilestoneStatusUpdateResponse {
+	@JsonProperty("success")
 	private final boolean success;
 
 	private MilestoneStatusUpdateResponse(boolean success) {
@@ -9,9 +12,5 @@ public class MilestoneStatusUpdateResponse {
 
 	public static MilestoneStatusUpdateResponse success() {
 		return new MilestoneStatusUpdateResponse(true);
-	}
-
-	public boolean isSuccess() {
-		return success;
 	}
 }

--- a/backend/src/main/java/codesquard/app/milestone/dto/response/MilestoneUpdateResponse.java
+++ b/backend/src/main/java/codesquard/app/milestone/dto/response/MilestoneUpdateResponse.java
@@ -1,6 +1,9 @@
 package codesquard.app.milestone.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class MilestoneUpdateResponse {
+	@JsonProperty("success")
 	private final boolean success;
 
 	private MilestoneUpdateResponse(boolean success) {
@@ -9,9 +12,5 @@ public class MilestoneUpdateResponse {
 
 	public static MilestoneUpdateResponse success() {
 		return new MilestoneUpdateResponse(true);
-	}
-
-	public boolean isSuccess() {
-		return success;
 	}
 }

--- a/backend/src/main/java/codesquard/app/milestone/dto/response/MilestoneUpdateResponse.java
+++ b/backend/src/main/java/codesquard/app/milestone/dto/response/MilestoneUpdateResponse.java
@@ -7,8 +7,8 @@ public class MilestoneUpdateResponse {
 		this.success = success;
 	}
 
-	public static MilestoneUpdateResponse success(boolean success) {
-		return new MilestoneUpdateResponse(success);
+	public static MilestoneUpdateResponse success() {
+		return new MilestoneUpdateResponse(true);
 	}
 
 	public boolean isSuccess() {

--- a/backend/src/main/java/codesquard/app/milestone/dto/response/MilestonesResponse.java
+++ b/backend/src/main/java/codesquard/app/milestone/dto/response/MilestonesResponse.java
@@ -4,17 +4,27 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Map;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import codesquard.app.milestone.entity.Milestone;
 import codesquard.app.milestone.entity.MilestoneStatus;
 
 public class MilestonesResponse {
+	@JsonProperty("id")
 	private Long id; // 등록번호
+	@JsonProperty("status")
 	private MilestoneStatus status; // OPEN, CLOSE
+	@JsonProperty("name")
 	private String name; // 이름
+	@JsonProperty("description")
 	private String description; // 설명
+	@JsonProperty("createdAt")
 	private LocalDateTime createdAt; // 생성 시간
+	@JsonProperty("modifiedAt")
 	private LocalDateTime modifiedAt; // 수정 시간
+	@JsonProperty("deadline")
 	private LocalDate deadline; // 완료일
+	@JsonProperty("issues")
 	private Map<String, Long> issues; // 이슈 카운트
 
 	private MilestonesResponse(Long id, MilestoneStatus status, String name, String description,
@@ -33,37 +43,5 @@ public class MilestonesResponse {
 		return new MilestonesResponse(milestone.getId(), milestone.getStatus(), milestone.getName(),
 			milestone.getDescription(), milestone.getCreatedAt(), milestone.getModifiedAt(), milestone.getDeadline(),
 			issues);
-	}
-
-	public Long getId() {
-		return id;
-	}
-
-	public MilestoneStatus getStatus() {
-		return status;
-	}
-
-	public String getName() {
-		return name;
-	}
-
-	public String getDescription() {
-		return description;
-	}
-
-	public LocalDateTime getCreatedAt() {
-		return createdAt;
-	}
-
-	public LocalDateTime getModifiedAt() {
-		return modifiedAt;
-	}
-
-	public LocalDate getDeadline() {
-		return deadline;
-	}
-
-	public Map<String, Long> getIssues() {
-		return issues;
 	}
 }

--- a/backend/src/main/java/codesquard/app/milestone/dto/response/MilestonesResponse.java
+++ b/backend/src/main/java/codesquard/app/milestone/dto/response/MilestonesResponse.java
@@ -1,0 +1,69 @@
+package codesquard.app.milestone.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import codesquard.app.milestone.entity.Milestone;
+import codesquard.app.milestone.entity.MilestoneStatus;
+
+public class MilestonesResponse {
+	private Long id; // 등록번호
+	private MilestoneStatus status; // OPEN, CLOSE
+	private String name; // 이름
+	private String description; // 설명
+	private LocalDateTime createdAt; // 생성 시간
+	private LocalDateTime modifiedAt; // 수정 시간
+	private LocalDate deadline; // 완료일
+	private Map<String, Long> issues; // 이슈 카운트
+
+	private MilestonesResponse(Long id, MilestoneStatus status, String name, String description,
+		LocalDateTime createdAt, LocalDateTime modifiedAt, LocalDate deadline, Map<String, Long> issues) {
+		this.id = id;
+		this.status = status;
+		this.name = name;
+		this.description = description;
+		this.createdAt = createdAt;
+		this.modifiedAt = modifiedAt;
+		this.deadline = deadline;
+		this.issues = issues;
+	}
+
+	public static MilestonesResponse fromEntity(final Milestone milestone, final Map<String, Long> issues) {
+		return new MilestonesResponse(milestone.getId(), milestone.getStatus(), milestone.getName(),
+			milestone.getDescription(), milestone.getCreatedAt(), milestone.getModifiedAt(), milestone.getDeadline(),
+			issues);
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public MilestoneStatus getStatus() {
+		return status;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public LocalDateTime getCreatedAt() {
+		return createdAt;
+	}
+
+	public LocalDateTime getModifiedAt() {
+		return modifiedAt;
+	}
+
+	public LocalDate getDeadline() {
+		return deadline;
+	}
+
+	public Map<String, Long> getIssues() {
+		return issues;
+	}
+}

--- a/backend/src/main/java/codesquard/app/milestone/entity/Milestone.java
+++ b/backend/src/main/java/codesquard/app/milestone/entity/Milestone.java
@@ -5,16 +5,62 @@ import java.time.LocalDateTime;
 
 public class Milestone {
 	private Long id; // 등록번호
-	private boolean status; // true: open, false: close
-	private LocalDateTime statusModifiedAt; // 상태(open/close)변경시간
+	private MilestoneStatus status; // OPEN, CLOSE
+	private LocalDateTime statusModifiedAt; // 상태(open/close) 변경 시간
+	private LocalDateTime createdAt; // 생성 시간
+	private LocalDateTime modifiedAt; // 수정 시간
 	private String name; // 이름
 	private String description; // 설명
 	private LocalDate deadline; // 완료일
+
+	public Milestone(String status) {
+		chooseStatus(status);
+	}
 
 	public Milestone(String name, String description, LocalDate deadline) {
 		this.name = name;
 		this.description = description;
 		this.deadline = deadline;
+	}
+
+	public Milestone(Long id, String status, LocalDateTime createdAt, LocalDateTime modifiedAt, String name,
+		String description, LocalDate deadline) {
+		this.id = id;
+		chooseStatus(status);
+		this.createdAt = createdAt;
+		this.modifiedAt = modifiedAt;
+		this.name = name;
+		this.description = description;
+		this.deadline = deadline;
+	}
+
+	private void chooseStatus(String status) {
+		if (status.equalsIgnoreCase("OPENED")) {
+			this.status = MilestoneStatus.OPENED;
+			return;
+		}
+
+		this.status = MilestoneStatus.CLOSED;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public MilestoneStatus getStatus() {
+		return status;
+	}
+
+	public LocalDateTime getStatusModifiedAt() {
+		return statusModifiedAt;
+	}
+
+	public LocalDateTime getCreatedAt() {
+		return createdAt;
+	}
+
+	public LocalDateTime getModifiedAt() {
+		return modifiedAt;
 	}
 
 	public String getName() {

--- a/backend/src/main/java/codesquard/app/milestone/entity/MilestoneStatus.java
+++ b/backend/src/main/java/codesquard/app/milestone/entity/MilestoneStatus.java
@@ -1,0 +1,9 @@
+package codesquard.app.milestone.entity;
+
+public enum MilestoneStatus {
+	OPENED, CLOSED;
+
+	public String getName() {
+		return this.name();
+	}
+}

--- a/backend/src/main/java/codesquard/app/milestone/repository/JdbcMilestoneRepository.java
+++ b/backend/src/main/java/codesquard/app/milestone/repository/JdbcMilestoneRepository.java
@@ -1,10 +1,16 @@
 package codesquard.app.milestone.repository;
 
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -14,6 +20,7 @@ import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
 
 import codesquard.app.milestone.entity.Milestone;
+import codesquard.app.milestone.entity.MilestoneStatus;
 
 @Repository
 public class JdbcMilestoneRepository implements MilestoneRepository {
@@ -26,8 +33,8 @@ public class JdbcMilestoneRepository implements MilestoneRepository {
 
 	@Override
 	public Optional<Long> save(Milestone milestone) {
-		String sql = "INSERT INTO `milestone` (`name`, `deadline`, `description`) "
-			+ "VALUES (:name, :deadline, :description)";
+		String sql = "INSERT INTO `milestone` (`name`, `deadline`, `description`) " +
+			"VALUES (:name, :deadline, :description)";
 
 		SqlParameterSource param = new BeanPropertySqlParameterSource(milestone);
 		KeyHolder keyHolder = new GeneratedKeyHolder();
@@ -38,26 +45,87 @@ public class JdbcMilestoneRepository implements MilestoneRepository {
 	}
 
 	@Override
-	public List<Milestone> findAll() {
-		return null;
+	public Long countIssuesBy(MilestoneStatus status) {
+		String sql = "SELECT COUNT(*) FROM `issue` " +
+			"WHERE `status` = :status";
+
+		Map<String, Object> paramMap = new HashMap<>();
+		paramMap.put("status", status.getName());
+
+		return Optional.ofNullable(template.queryForObject(sql, paramMap, Long.class)).orElse(0L);
 	}
 
 	@Override
-	public Milestone findById(Long id) {
-		return null;
+	public Long countMilestonesBy(MilestoneStatus status) {
+		String sql = "SELECT COUNT(*) FROM `milestone` " +
+			"WHERE `status` = :status";
+
+		Map<String, Object> paramMap = new HashMap<>();
+		paramMap.put("status", status.getName());
+
+		return Optional.ofNullable(template.queryForObject(sql, paramMap, Long.class)).orElse(0L);
+	}
+
+	@Override
+	public Long countLabels() {
+		String sql = "SELECT COUNT(*) FROM `label` ";
+
+		Map<String, Object> paramMap = new HashMap<>();
+
+		return Optional.ofNullable(template.queryForObject(sql, paramMap, Long.class)).orElse(0L);
+	}
+
+	@Override
+	public List<Milestone> findAllBy(MilestoneStatus status) {
+		String sql = "SELECT `id`, `status`, `name`, `description`, `created_at`, `modified_at`, `deadline` " +
+			"FROM `milestone` " +
+			"WHERE status = :status";
+
+		SqlParameterSource param = new MapSqlParameterSource("status", status.getName());
+
+		return Optional.of(template.query(sql, param, milestoneRowMapper())).orElse(Collections.emptyList());
+	}
+
+	private RowMapper<Milestone> milestoneRowMapper() {
+		return (rs, rowNum) -> {
+			Long id = rs.getLong("id");
+			String status = rs.getString("status");
+			Optional<LocalDateTime> createdAt = Optional.ofNullable(rs.getTimestamp("created_at"))
+				.map(Timestamp::toLocalDateTime);
+			Optional<LocalDateTime> modifiedAt = Optional.ofNullable(rs.getTimestamp("modified_at"))
+				.map(Timestamp::toLocalDateTime);
+			String name = rs.getString("name");
+			String description = rs.getString("description");
+			Optional<LocalDate> deadline = Optional.ofNullable(rs.getDate("deadline")).map(Date::toLocalDate);
+
+			return new Milestone(id, status, createdAt.orElse(null), modifiedAt.orElse(null), name, description,
+				deadline.orElse(null));
+		};
 	}
 
 	@Override
 	public void updateBy(Long milestoneId, Milestone milestone) {
 		String sql = "UPDATE `milestone` " +
-			"SET `name` = :name, `deadline` = :deadline, `description` = :description, `modified_at` = :modifiedAt " +
+			"SET `name` = :name, `deadline` = :deadline, `description` = :description " +
 			"WHERE id = :id";
 
 		SqlParameterSource param = new MapSqlParameterSource()
 			.addValue("name", milestone.getName())
 			.addValue("deadline", milestone.getDeadline())
 			.addValue("description", milestone.getDescription())
-			.addValue("modifiedAt", LocalDateTime.now())
+			.addValue("id", milestoneId);
+
+		template.update(sql, param);
+	}
+
+	@Override
+	public void updateBy(Long milestoneId, MilestoneStatus status) {
+		String sql = "UPDATE `milestone` " +
+			"SET `status` = :status " +
+			"WHERE id = :id";
+
+		SqlParameterSource param = new MapSqlParameterSource()
+			.addValue("status", status.getName())
 			.addValue("id", milestoneId);
 
 		template.update(sql, param);

--- a/backend/src/main/java/codesquard/app/milestone/repository/MilestoneRepository.java
+++ b/backend/src/main/java/codesquard/app/milestone/repository/MilestoneRepository.java
@@ -4,15 +4,22 @@ import java.util.List;
 import java.util.Optional;
 
 import codesquard.app.milestone.entity.Milestone;
+import codesquard.app.milestone.entity.MilestoneStatus;
 
 public interface MilestoneRepository {
 	Optional<Long> save(final Milestone milestone);
 
-	List<Milestone> findAll();
+	List<Milestone> findAllBy(final MilestoneStatus status);
 
-	Milestone findById(final Long id);
+	Long countIssuesBy(MilestoneStatus status);
+
+	Long countMilestonesBy(MilestoneStatus status);
+
+	Long countLabels();
 
 	void updateBy(final Long milestoneId, final Milestone milestone);
+
+	void updateBy(final Long milestoneId, final MilestoneStatus status);
 
 	void deleteBy(final Long milestoneId);
 }

--- a/backend/src/main/java/codesquard/app/milestone/service/MilestoneService.java
+++ b/backend/src/main/java/codesquard/app/milestone/service/MilestoneService.java
@@ -1,11 +1,20 @@
 package codesquard.app.milestone.service;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import codesquard.app.milestone.dto.request.MilestoneSaveRequest;
+import codesquard.app.milestone.dto.request.MilestoneStatusRequest;
 import codesquard.app.milestone.dto.request.MilestoneUpdateRequest;
+import codesquard.app.milestone.dto.response.MilestoneReadResponse;
+import codesquard.app.milestone.dto.response.MilestonesResponse;
 import codesquard.app.milestone.entity.Milestone;
+import codesquard.app.milestone.entity.MilestoneStatus;
 import codesquard.app.milestone.repository.MilestoneRepository;
 
 @Service
@@ -28,7 +37,46 @@ public class MilestoneService {
 	}
 
 	@Transactional
+	public void updateMilestoneStatus(Long milestoneId, MilestoneStatusRequest milestoneStatusRequest) {
+		milestoneRepository.updateBy(milestoneId, MilestoneStatusRequest.toStatus(milestoneStatusRequest));
+	}
+
+	@Transactional
 	public void deleteMilestone(Long milestoneId) {
 		milestoneRepository.deleteBy(milestoneId);
+	}
+
+	@Transactional
+	public MilestoneReadResponse makeMilestoneResponse(MilestoneStatus status) {
+		// 1. milestones 배열 (이 List가 여러개 있는 2차원 배열이라고 생각하면 됨)
+		// makeIssues(): issues를 `countIssuesBy()`로 milestoneStatus별로 각각 1번씩 가져오기
+		// id ~ deadline까지 `findAllBy()`로 가져와서 issues랑 합치기
+		List<MilestonesResponse> milestones = sumMilestonesResponseAndIssues(status, makeIssues());
+
+		// 2. labelCount 가져오기
+		Long labelCount = milestoneRepository.countLabels();
+
+		// 3. openedMilestoneCount, closedMilestoneCount 가져오기 (List로 묶는 거 아님)
+		Long openedMilestoneCount = milestoneRepository.countMilestonesBy(MilestoneStatus.OPENED);
+		Long closedMilestoneCount = milestoneRepository.countMilestonesBy(MilestoneStatus.CLOSED);
+
+		// 4. 3개의 단일 객체와, 나머지 1개의 2차원 배열로 이루어진 것을 MilestoneReadResponse에 담으면 됨
+		return new MilestoneReadResponse(openedMilestoneCount, closedMilestoneCount, labelCount, milestones);
+	}
+
+	private Map<String, Long> makeIssues() {
+		Map<String, Long> issues = new HashMap<>();
+		issues.put("openedIssueCount", milestoneRepository.countIssuesBy(MilestoneStatus.OPENED));
+		issues.put("closedIssueCount", milestoneRepository.countIssuesBy(MilestoneStatus.CLOSED));
+
+		return issues;
+	}
+
+	private List<MilestonesResponse> sumMilestonesResponseAndIssues(MilestoneStatus status, Map<String, Long> issues) {
+		return milestoneRepository.findAllBy(status)
+			.stream()
+			// 미리 생성해둔 issues 배열을 각 milestone 객체마다 넣어줌
+			.map(milestone -> MilestonesResponse.fromEntity(milestone, issues))
+			.collect(Collectors.toUnmodifiableList());
 	}
 }


### PR DESCRIPTION
## Description

- status를 위한 업데이트 코드를 작성하지 않았어서 api 명세서에 추가 후 `/status` 주소로 구현하였습니다.
- Service 레이어의 `makeMilestoneResponse()` 메서드 안에 많은 메서드들이 들어 있습니다.
  - 이 메서드를 컨트롤러에서 호출 후 조합하는 것도 생각해 봤는데 어떤 방법이 나을까요?
- 레포지토리에서 null 값을 Optional로 처리했습니다.

## Next Step

- 라벨 READ API 기능 구현
