### PR TITLE
[fe] label page 구현 및 리팩토링

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider, styled } from "styled-components";
 import { Header } from "./components/Header";
 import { designSystem } from "./constants/designSystem";
 import { Error404 } from "./page/Error404";
+import { Label } from "./page/label/Label";
 import { Main } from "./page/main/Main";
 
 export default function App() {
@@ -16,6 +17,7 @@ export default function App() {
           <Header />
           <Routes>
             <Route path="/" element={<Main />} />
+            <Route path="/label" element={<Label />} />
             <Route path="*" element={<Error404 />} />
           </Routes>
         </Router>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,7 +8,7 @@ import { Label } from "./page/label/Label";
 import { Main } from "./page/main/Main";
 
 export default function App() {
-  const [themeMode, setThemeMode] = useState<"light" | "dark">("light");
+  const [themeMode, setThemeMode] = useState<"LIGHT" | "DARK">("LIGHT");
 
   return (
     <Div>

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -8,6 +8,7 @@ type ButtonProps = {
   flexible?: "Flexible" | "Fixed";
   icon?: string;
   selected?: boolean;
+  color?: string;
 } & ButtonHTMLAttributes<HTMLButtonElement>;
 
 export function Button({
@@ -17,23 +18,26 @@ export function Button({
   icon,
   selected,
   children,
+  color,
   ...props
 }: ButtonProps) {
   const buttonMap = {
-    Container: ConatinerButton,
+    Container: ContainerButton,
     Outline: OutlineButton,
     Ghost: GhostButton,
   };
-  
+
   const theme = useTheme();
   const iconColorMap = {
     Container: theme.color.brandTextDefault,
     Outline: theme.color.brandTextWeak,
-    Ghost: selected ? theme.color.neutralTextStrong : theme.color.neutralTextDefault,
-  }
+    Ghost: selected
+      ? theme.color.neutralTextStrong
+      : theme.color.neutralTextDefault,
+  };
 
   const ButtonComponent = buttonMap[buttonType];
-  const iconColor = iconColorMap[buttonType];
+  const iconColor = color || iconColorMap[buttonType];
 
   return (
     <ButtonComponent
@@ -41,10 +45,11 @@ export function Button({
       $size={size}
       $flexible={flexible === "Flexible"}
       $selected={selected}
+      $color={color}
       {...props}
     >
       <div>
-        {icon && <Icon name={icon} fill={iconColor} stroke={iconColor}/>}
+        {icon && <Icon name={icon} fill={iconColor} stroke={iconColor} />}
         <span>{children}</span>
       </div>
     </ButtonComponent>
@@ -54,6 +59,7 @@ export function Button({
 const StyledButton = styled.button<{
   $size: "S" | "M" | "L";
   $flexible?: boolean;
+  $color?: string;
 }>`
   width: ${({ $size, $flexible }) => {
     if ($flexible) {
@@ -122,15 +128,15 @@ const StyledButton = styled.button<{
   }
 `;
 
-const ConatinerButton = styled(StyledButton)`
+const ContainerButton = styled(StyledButton)`
   background-color: ${({ theme }) => theme.color.brandSurfaceDefault};
-  color: ${({ theme }) => theme.color.brandTextDefault};
+  color: ${({ theme, $color }) => $color || theme.color.brandTextDefault};
 `;
 
 const OutlineButton = styled(StyledButton)`
   border: ${({ theme }) =>
     theme.border.default + theme.color.brandBorderDefault};
-  color: ${({ theme }) => theme.color.brandTextWeak};
+  color: ${({ theme, $color }) => $color || theme.color.brandTextWeak};
 `;
 
 const GhostButton = styled(StyledButton)<{ $selected?: boolean }>`
@@ -152,6 +158,9 @@ const GhostButton = styled(StyledButton)<{ $selected?: boolean }>`
         return "";
     }
   }};
-  color: ${({ theme, $selected }) =>
-    $selected ? theme.color.neutralTextStrong : theme.color.neutralTextDefault};
+  color: ${({ theme, $selected, $color }) =>
+    $color ||
+    ($selected
+      ? theme.color.neutralTextStrong
+      : theme.color.neutralTextDefault)};
 `;

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,22 +1,26 @@
+import { useNavigate } from "react-router-dom";
 import { styled } from "styled-components";
 import { Icon } from "./Icon";
 
 export function Header() {
+  const navigate = useNavigate();
+
   return (
-    <Div>
+    <Anchor onClick={() => navigate("/")}>
       <Icon name="logoLightMedium" />
       <img
         style={{ width: "32px" }}
         src="https://avatars.githubusercontent.com/u/41321198?v=4"
       />
-    </Div>
+    </Anchor>
   );
 }
 
-const Div = styled.div`
+const Anchor = styled.a`
   width: 1280px;
   display: inline-flex;
   padding: 27px 80px;
   justify-content: space-between;
   align-items: center;
+  cursor: pointer;
 `;

--- a/frontend/src/components/InformationTag.tsx
+++ b/frontend/src/components/InformationTag.tsx
@@ -38,24 +38,24 @@ export function InformationTag({
   );
 }
 
-const getBorderColor = (hexColor: string | undefined): string => {
-  const theme = useTheme();
-
+function getBorderColor(hexColor: string | undefined): string {
   if (!hexColor || hexColor.length !== 7 || !hexColor.startsWith("#")) {
     return "transparent";
   }
 
-  hexColor = hexColor.substr(1); // Remove the # sign
+  hexColor = hexColor.replace("#", "");
 
-  const r = parseInt(hexColor.substr(0, 2), 16);
-  const g = parseInt(hexColor.substr(2, 2), 16);
-  const b = parseInt(hexColor.substr(4, 2), 16);
+  const r = parseInt(hexColor.substring(0, 2), 16);
+  const g = parseInt(hexColor.substring(2, 2), 16);
+  const b = parseInt(hexColor.substring(4, 2), 16);
   const brightness = Math.round((r * 299 + g * 587 + b * 114) / 1000);
+
+  const theme = useTheme();
 
   return brightness > 200 && brightness <= 255
     ? theme.color.neutralBorderDefault
     : "transparent";
-};
+}
 
 const StyledInformationTag = styled.div<{
   $size: "M" | "S";

--- a/frontend/src/components/InformationTag.tsx
+++ b/frontend/src/components/InformationTag.tsx
@@ -8,7 +8,7 @@ export function InformationTag({
   icon,
   fill,
   stroke,
-  fontColor = "Dark",
+  fontColor = "DARK",
 }: {
   value: string;
   size: "M" | "S";
@@ -16,12 +16,13 @@ export function InformationTag({
   icon?: string;
   fill?: string;
   stroke?: "Default" | "DefaultActive";
-  fontColor?: "Light" | "Dark";
+  fontColor?: "LIGHT" | "DARK";
 }) {
   const theme = useTheme();
-  const iconColor = fontColor === "Dark"
-  ? theme.color.neutralTextWeak
-  : theme.color.brandTextDefault;
+  const iconColor =
+    fontColor === "DARK"
+      ? theme.color.neutralTextWeak
+      : theme.color.brandTextDefault;
 
   return (
     <StyledInformationTag
@@ -29,9 +30,9 @@ export function InformationTag({
       $size={size}
       $fill={fill}
       $stroke={stroke}
-      $darkFont={fontColor === "Dark"}
+      $darkFont={fontColor === "DARK"}
     >
-      {icon && <Icon name={icon} fill={iconColor} stroke={iconColor}/>}
+      {icon && <Icon name={icon} fill={iconColor} stroke={iconColor} />}
       <span>{value}</span>
     </StyledInformationTag>
   );

--- a/frontend/src/components/InformationTag.tsx
+++ b/frontend/src/components/InformationTag.tsx
@@ -38,7 +38,7 @@ export function InformationTag({
   );
 }
 
-function getBorderColor(hexColor: string | undefined): string {
+const getBorderColor = (hexColor: string | undefined): string => {
   if (!hexColor || hexColor.length !== 7 || !hexColor.startsWith("#")) {
     return "transparent";
   }
@@ -46,8 +46,8 @@ function getBorderColor(hexColor: string | undefined): string {
   hexColor = hexColor.replace("#", "");
 
   const r = parseInt(hexColor.substring(0, 2), 16);
-  const g = parseInt(hexColor.substring(2, 2), 16);
-  const b = parseInt(hexColor.substring(4, 2), 16);
+  const g = parseInt(hexColor.substring(2, 4), 16);
+  const b = parseInt(hexColor.substring(4, 6), 16);
   const brightness = Math.round((r * 299 + g * 587 + b * 114) / 1000);
 
   const theme = useTheme();
@@ -55,7 +55,7 @@ function getBorderColor(hexColor: string | undefined): string {
   return brightness > 200 && brightness <= 255
     ? theme.color.neutralBorderDefault
     : "transparent";
-}
+};
 
 const StyledInformationTag = styled.div<{
   $size: "M" | "S";

--- a/frontend/src/components/InformationTag.tsx
+++ b/frontend/src/components/InformationTag.tsx
@@ -38,6 +38,25 @@ export function InformationTag({
   );
 }
 
+const getBorderColor = (hexColor: string | undefined): string => {
+  const theme = useTheme();
+
+  if (!hexColor || hexColor.length !== 7 || !hexColor.startsWith("#")) {
+    return "transparent";
+  }
+
+  hexColor = hexColor.substr(1); // Remove the # sign
+
+  const r = parseInt(hexColor.substr(0, 2), 16);
+  const g = parseInt(hexColor.substr(2, 2), 16);
+  const b = parseInt(hexColor.substr(4, 2), 16);
+  const brightness = Math.round((r * 299 + g * 587 + b * 114) / 1000);
+
+  return brightness > 200 && brightness <= 255
+    ? theme.color.neutralBorderDefault
+    : "transparent";
+};
+
 const StyledInformationTag = styled.div<{
   $size: "M" | "S";
   $fill?: string;
@@ -51,10 +70,10 @@ const StyledInformationTag = styled.div<{
   height: ${({ $size }) => ($size === "M" ? "32px" : "24px")};
   padding: ${({ $size }) => ($size === "M" ? "0 16px" : "0 8px")};
   border: 1px solid
-    ${({ theme, $stroke }) =>
+    ${({ theme, $stroke, $fill }) =>
       $stroke && theme.color[`neutralBorder${$stroke}`]
         ? theme.color[`neutralBorder${$stroke}`]
-        : "transparent"};
+        : getBorderColor($fill)};
   border-radius: ${({ theme }) => theme.radius.large};
   background-color: ${({ theme, $fill }) =>
     $fill && /^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$/g.test($fill)

--- a/frontend/src/components/TextInput.tsx
+++ b/frontend/src/components/TextInput.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import styled from "styled-components";
+import styled, { useTheme } from "styled-components";
 import { Icon } from "./Icon";
 
 type TextInputProps = {
@@ -14,7 +14,7 @@ type TextInputProps = {
   borderNone?: boolean;
   disabled?: boolean;
   isError?: boolean;
-  onChange?: () => void;
+  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   onFocus?: () => void;
   onBlur?: () => void;
 };
@@ -55,13 +55,17 @@ export function TextInput({
 
   useEffect(() => {
     setState(isError ? "Error" : "Enabled");
-  }, [inputValue, isError]);
+  }, [isError]);
+
+  useEffect(() => {
+    setInputValue(initialValue);
+  }, [initialValue]);
 
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value;
 
     setInputValue(value);
-    onChange && onChange();
+    onChange && onChange(event);
   };
 
   const handleInputFocus = () => {
@@ -80,8 +84,11 @@ export function TextInput({
     onBlur && onBlur();
   };
 
+  const theme = useTheme();
+  const iconColor = theme.color.neutralTextDefault;
+
   return (
-    <Div $state={state}>
+    <Div $state={state} $width={width}>
       <InputContainer
         $width={width}
         $size={size}
@@ -91,7 +98,7 @@ export function TextInput({
         {(fixLabel || inputValue) && label && <StyledSpan>{label}</StyledSpan>}
         {icon && (
           <IconWrapper>
-            <Icon name={icon} />
+            <Icon name={icon} fill={iconColor} stroke={iconColor} />
           </IconWrapper>
         )}
         <Input
@@ -109,9 +116,9 @@ export function TextInput({
   );
 }
 
-const Div = styled.div<{ $state: TextInputState }>`
+const Div = styled.div<{ $state: TextInputState; $width: number }>`
   display: flex;
-  width: 288px;
+  width: ${({ $width }) => $width}px;
   flex-direction: column;
   align-items: flex-start;
   gap: 4px;
@@ -125,7 +132,6 @@ const InputContainer = styled.div<InputContainerProps>`
   width: ${({ $width }) => $width}px;
   height: ${({ $size }) => ($size === "L" ? "56px" : "40px")};
   padding: 0px 16px;
-  justify-content: center;
   align-self: stretch;
   flex-direction: ${({ $size }) => ($size === "L" ? "column" : "")};
   align-items: ${({ $size }) => ($size === "L" ? "flex-start" : "center")};
@@ -171,6 +177,7 @@ const IconWrapper = styled.div`
 `;
 
 const Input = styled.input<InputProps>`
+  width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
   border: none;

--- a/frontend/src/components/dropdown/DropdownContainer.tsx
+++ b/frontend/src/components/dropdown/DropdownContainer.tsx
@@ -17,7 +17,7 @@ export function DropdownContainer({
     name: string;
     profile?: string;
     background?: string;
-    color?: "Light" | "Dark";
+    color?: "LIGHT" | "DARK";
     selected: boolean;
     onClick: () => void;
   }[];

--- a/frontend/src/components/dropdown/DropdownIndicator.tsx
+++ b/frontend/src/components/dropdown/DropdownIndicator.tsx
@@ -28,7 +28,7 @@ const StyledButton = styled.button`
   justify-content: center;
   align-items: center;
   gap: 8px;
-  height: 32px;
+  height: 100%;
   border-radius: 20px;
   font: ${({ theme }) => theme.font.availableMedium16};
   color: ${({ theme }) => theme.color.neutralTextDefault};

--- a/frontend/src/components/dropdown/DropdownOption.tsx
+++ b/frontend/src/components/dropdown/DropdownOption.tsx
@@ -5,7 +5,7 @@ export function DropdownOption({
   showProfile = true,
   profile,
   background,
-  color = "Light",
+  color = "LIGHT",
   selected,
   children,
   onClick,
@@ -13,7 +13,7 @@ export function DropdownOption({
   showProfile?: boolean;
   profile?: string;
   background?: string;
-  color?: "Light" | "Dark";
+  color?: "LIGHT" | "DARK";
   selected: boolean;
   children: string;
   onClick: () => void;
@@ -28,7 +28,10 @@ export function DropdownOption({
       {showProfile && profile ? (
         <img style={{ width: "20px" }} src={profile} alt="프로필 이미지" />
       ) : (
-        <Icon name="userImageSmall" fill={background ?? theme.color.neutralSurfaceBold}/>
+        <Icon
+          name="userImageSmall"
+          fill={background ?? theme.color.neutralSurfaceBold}
+        />
       )}
       <span title={children}>{children}</span>
       <Icon name={`check${selected ? "On" : "Off"}Circle`} />

--- a/frontend/src/components/dropdown/DropdownPanel.tsx
+++ b/frontend/src/components/dropdown/DropdownPanel.tsx
@@ -14,7 +14,7 @@ export function DropdownPanel({
     name: string;
     profile?: string;
     background?: string;
-    color?: "Light" | "Dark";
+    color?: "LIGHT" | "DARK";
     selected: boolean;
     onClick: () => void;
   }[];
@@ -23,19 +23,21 @@ export function DropdownPanel({
     <StyledPanel $alignment={alignment}>
       <div className="dropdown__header">{optionTitle}</div>
       <ul>
-        {options.map(({ name, profile, background, color, selected, onClick }, index) => (
-          <DropdownOption
-            key={`dropdown-option-${index}`}
-            showProfile={showProfile}
-            profile={profile}
-            background={background}
-            color={color}
-            selected={selected}
-            onClick={onClick}
-          >
-            {name}
-          </DropdownOption>
-        ))}
+        {options.map(
+          ({ name, profile, background, color, selected, onClick }, index) => (
+            <DropdownOption
+              key={`dropdown-option-${index}`}
+              showProfile={showProfile}
+              profile={profile}
+              background={background}
+              color={color}
+              selected={selected}
+              onClick={onClick}
+            >
+              {name}
+            </DropdownOption>
+          ),
+        )}
       </ul>
     </StyledPanel>
   );

--- a/frontend/src/components/issue/Issue.tsx
+++ b/frontend/src/components/issue/Issue.tsx
@@ -1,15 +1,15 @@
 import { styled, useTheme } from "styled-components";
 import { IssueData } from "../../page/main/Main";
 import { getElapsedSince } from "../../utils/getElapsedSince";
-import { InformationTag } from "../InformationTag";
 import { Icon } from "../Icon";
+import { InformationTag } from "../InformationTag";
 
 export function Issue({ issue }: { issue: IssueData }) {
   const theme = useTheme();
   const iconColors = {
     issueTitle: theme.color.paletteBlue,
     issueInfo: theme.color.neutralTextWeak,
-  }
+  };
 
   return (
     <Div>
@@ -20,7 +20,11 @@ export function Issue({ issue }: { issue: IssueData }) {
       </div>
       <IssueContent>
         <IssueTitle>
-          <Icon name="alertCircle" fill={iconColors.issueTitle} stroke={iconColors.issueTitle} />
+          <Icon
+            name="alertCircle"
+            fill={iconColors.issueTitle}
+            stroke={iconColors.issueTitle}
+          />
           <TitleAnchor>{issue.title}</TitleAnchor>
           {issue.labels.map((label, index) => (
             <InformationTag
@@ -28,7 +32,7 @@ export function Issue({ issue }: { issue: IssueData }) {
               value={label.name}
               size="S"
               fill={label.background}
-              fontColor="Light"
+              fontColor="LIGHT"
             />
           ))}
         </IssueTitle>
@@ -41,7 +45,11 @@ export function Issue({ issue }: { issue: IssueData }) {
           </span>
           {issue.milestone && (
             <span>
-              <Icon name="milestone" fill={iconColors.issueInfo} stroke={iconColors.issueInfo} />
+              <Icon
+                name="milestone"
+                fill={iconColors.issueInfo}
+                stroke={iconColors.issueInfo}
+              />
               {issue.milestone.name}
             </span>
           )}

--- a/frontend/src/constants/designSystem.ts
+++ b/frontend/src/constants/designSystem.ts
@@ -49,7 +49,7 @@ const opacity = {
   disabled: "0.32",
 };
 
-const light = {
+const LIGHT = {
   color: {
     neutralTextWeak: color.grayScale600,
     neutralTextDefault: color.grayScale700,
@@ -84,10 +84,10 @@ const light = {
       "brightness(0) saturate(100%) invert(30%) sepia(47%) saturate(3393%) hue-rotate(200deg) brightness(103%) contrast(112%)",
     brandTextDefault:
       "brightness(0) saturate(100%) invert(94%) sepia(32%) saturate(0%) hue-rotate(6deg) brightness(105%) contrast(99%)",
-  }
+  },
 };
 
-const dark = {
+const DARK = {
   color: {
     neutralTextWeak: color.grayScale500,
     neutralTextDefault: color.grayScale400,
@@ -122,22 +122,22 @@ const dark = {
       "brightness(0) saturate(100%) invert(30%) sepia(47%) saturate(3393%) hue-rotate(200deg) brightness(103%) contrast(112%)",
     brandTextDefault:
       "brightness(0) saturate(100%) invert(94%) sepia(32%) saturate(0%) hue-rotate(6deg) brightness(105%) contrast(99%)",
-  }
+  },
 };
 
 export const designSystem = {
-  light: {
+  LIGHT: {
     font,
     radius,
     border,
     opacity,
-    ...light
+    ...LIGHT,
   },
-  dark: {
+  DARK: {
     font,
     radius,
     border,
     opacity,
-    ...dark
+    ...DARK,
   },
 };

--- a/frontend/src/page/label/Label.tsx
+++ b/frontend/src/page/label/Label.tsx
@@ -12,8 +12,14 @@ export type LabelData = {
   description: string | null;
 };
 
+type LabelsResData = {
+  openedMilestoneCount: Number;
+  labelCount: Number;
+  labels: LabelData[];
+};
+
 export function Label() {
-  const [labelsRes, setLabelsRes] = useState<{ labels: LabelData[] }>();
+  const [labelsRes, setLabelsRes] = useState<LabelsResData>();
   const [isAdding, setIsAdding] = useState(false);
 
   const openAddLabel = () => {
@@ -38,7 +44,14 @@ export function Label() {
 
   return (
     <Div>
-      <LabelHeader onClick={openAddLabel} isAdding={isAdding} />
+      {labelsRes && (
+        <LabelHeader
+          onClick={openAddLabel}
+          openedMilestoneCount={labelsRes.openedMilestoneCount}
+          labelCount={labelsRes.labelCount}
+          isAdding={isAdding}
+        />
+      )}
       {isAdding && (
         <EditorWrapper>
           <LabelEditor onClickClose={closeAddLabel} type="add" />

--- a/frontend/src/page/label/Label.tsx
+++ b/frontend/src/page/label/Label.tsx
@@ -7,7 +7,7 @@ import { LabelTable } from "./LabelTable";
 export type LabelData = {
   id: number;
   name: string;
-  color: "Light" | "Dark";
+  color: "LIGHT" | "DARK";
   background: string;
   description: string | null;
 };

--- a/frontend/src/page/label/Label.tsx
+++ b/frontend/src/page/label/Label.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react";
+import { styled } from "styled-components";
+import { LabelEditor } from "./LabelEditor";
+import { LabelHeader } from "./LabelHeader";
+import { LabelTable } from "./LabelTable";
+
+export type LabelData = {
+  id: number;
+  name: string;
+  color: "Light" | "Dark";
+  background: string;
+  description: string | null;
+};
+
+export function Label() {
+  const [labelsRes, setLabelsRes] = useState<{ labels: LabelData[] }>();
+  const [isAdding, setIsAdding] = useState(false);
+
+  const openAddLabel = () => {
+    setIsAdding(true);
+  };
+
+  const closeAddLabel = () => {
+    setIsAdding(false);
+  };
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const res = await fetch(
+        "https://8e24d81e-0591-4cf2-8200-546f93981656.mock.pstmn.io/api/labels",
+      );
+
+      setLabelsRes(await res.json());
+    };
+
+    fetchData();
+  }, []);
+
+  return (
+    <Div>
+      <LabelHeader onClick={openAddLabel} isAdding={isAdding} />
+      {isAdding && (
+        <EditorWrapper>
+          <LabelEditor onClickClose={closeAddLabel} type="add" />
+        </EditorWrapper>
+      )}
+      {labelsRes && <LabelTable labels={labelsRes.labels} />}
+    </Div>
+  );
+}
+
+const Div = styled.div`
+  width: 1280px;
+  display: flex;
+  flex-direction: column;
+`;
+
+const EditorWrapper = styled.div`
+  border: 1px solid ${({ theme }) => theme.color.neutralBorderDefault};
+  border-radius: ${({ theme }) => theme.radius.large};
+  margin-bottom: 24px;
+`;

--- a/frontend/src/page/label/LabelEditor.tsx
+++ b/frontend/src/page/label/LabelEditor.tsx
@@ -1,0 +1,291 @@
+import { useState } from "react";
+import { styled } from "styled-components";
+import { Button } from "../../components/Button";
+import { Icon } from "../../components/Icon";
+import { InformationTag } from "../../components/InformationTag";
+import { TextInput } from "../../components/TextInput";
+import { DropdownContainer } from "../../components/dropdown/DropdownContainer";
+import { LabelData } from "./Label";
+
+const colorDictionary = {
+  Light: "밝은 색",
+  Dark: "어두운 색",
+  "밝은 색": "Light",
+  "어두운 색": "Dark",
+};
+
+type LabelEditorProps = {
+  onClickClose: () => void;
+} & ({ type: "add"; label?: never } | { type: "edit"; label: LabelData });
+
+export function LabelEditor({ onClickClose, type, label }: LabelEditorProps) {
+  const isEditMode = type === "edit" && label;
+
+  const [dropDownName, setDropDownName] = useState<string>(
+    isEditMode ? colorDictionary[label.color] : "밝은 색",
+  );
+  const [background, setBackground] = useState(
+    isEditMode ? label.background : "#000000",
+  );
+  const [color, setColor] = useState<"Light" | "Dark">(
+    isEditMode ? label.color : "Light",
+  );
+  const [labelName, setLabelName] = useState(isEditMode ? label.name : "");
+  const [labelDescription, setLabelDescription] = useState(
+    isEditMode && label.description ? label.description : "",
+  );
+  const [isColorValid, setIsColorValid] = useState(true);
+  const [isFocus, setIsFocus] = useState(false);
+  const [options, setOptions] = useState([
+    {
+      name: "밝은 색",
+      profile: "",
+      selected: isEditMode ? colorDictionary[label.color] === "밝은 색" : true,
+      onClick: () => {
+        updateOptions("밝은 색");
+      },
+    },
+    {
+      name: "어두운 색",
+      profile: "",
+      selected: isEditMode
+        ? colorDictionary[label.color] === "어두운 색"
+        : false,
+      onClick: () => {
+        updateOptions("어두운 색");
+      },
+    },
+  ]);
+
+  const isButtonDisabled = isEditMode
+    ? !isColorValid ||
+      (labelName === label.name &&
+        background === label.background &&
+        color === label.color) ||
+      labelName === ""
+    : !isColorValid || labelName === "";
+
+  const updateOptions = (selectedName: string) => {
+    const fontColor = selectedName === "밝은 색" ? "Light" : "Dark";
+
+    setColor(fontColor);
+    setDropDownName(selectedName);
+    setOptions(
+      options.map((option) => {
+        return { ...option, selected: option.name === selectedName };
+      }),
+    );
+  };
+
+  const onChangeBackground = (event: React.ChangeEvent<HTMLInputElement>) => {
+    let value = event.target.value;
+
+    if (!value.startsWith("#")) {
+      value = "#" + value;
+    }
+
+    // hex값 체크
+    const isValidColor = /^#([0-9A-F]{3}){1,2}$/i.test(value);
+
+    setBackground(value);
+    setIsColorValid(isValidColor);
+  };
+
+  const setRandomBackground = () => {
+    const letters = "0123456789ABCDEF";
+    let color = "#";
+
+    for (let i = 0; i < 6; i++) {
+      color += letters[Math.floor(Math.random() * letters.length)];
+    }
+    setBackground(color);
+  };
+
+  const onChangeName = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const name = event.target.value;
+
+    setLabelName(name);
+  };
+
+  const onChangeDescription = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const description = event.target.value;
+
+    setLabelDescription(description);
+  };
+
+  const submit = () => {
+    const obj = {
+      name: labelName,
+      description: labelDescription,
+      background: background,
+      fontColor: color,
+    };
+
+    console.log(obj);
+  };
+
+  return (
+    <Div>
+      <Title>{type === "add" ? "새로운 레이블 추가" : "레이블 편집"}</Title>
+      <AddTable>
+        <Preview>
+          <InformationTag
+            value={labelName === "" ? "label" : labelName}
+            size="S"
+            fill={background}
+            fontColor={color}
+          />
+        </Preview>
+        <InputWrapper>
+          <TextInput
+            width={904}
+            size="S"
+            label="이름"
+            placeholder="레이블의 이름을 입력하세요"
+            value={labelName}
+            fixLabel
+            onChange={onChangeName}
+          />
+          <TextInput
+            width={904}
+            size="S"
+            label="설명(선택)"
+            placeholder="레이블에 대한 설명을 입력하세요"
+            fixLabel
+            value={labelDescription}
+            onChange={onChangeDescription}
+          />
+          <ColorSelector>
+            <BackgroundSelector $isFocus={isFocus} $isColorValid={isColorValid}>
+              <span>배경 색상</span>
+              <TextInput
+                size="S"
+                value={background}
+                borderNone
+                onFocus={() => setIsFocus(true)}
+                onBlur={() => setIsFocus(false)}
+                onChange={onChangeBackground}
+              />
+              <button onClick={setRandomBackground}>
+                <Icon name="refreshCcw" fill="#4E4B66" stroke="#4E4B66" />
+              </button>
+            </BackgroundSelector>
+            <DropdownContainer
+              name={dropDownName}
+              optionTitle={"텍스트 색상"}
+              options={options}
+              alignment="Left"
+            />
+          </ColorSelector>
+        </InputWrapper>
+      </AddTable>
+      <Buttons>
+        <Button
+          size="S"
+          icon="xSquare"
+          buttonType="Outline"
+          onClick={onClickClose}
+        >
+          취소
+        </Button>
+        <Button
+          size="S"
+          icon="plus"
+          buttonType="Container"
+          onClick={submit}
+          disabled={isButtonDisabled}
+        >
+          완료
+        </Button>
+      </Buttons>
+    </Div>
+  );
+}
+
+const Div = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 337px;
+  align-self: stretch;
+  box-sizing: border-box;
+  padding: 32px;
+  gap: 24px;
+`;
+
+const Title = styled.div`
+  font: ${({ theme }) => theme.font.displayBold20};
+  color: ${({ theme }) => theme.color.neutralTextStrong};
+`;
+
+const AddTable = styled.div`
+  width: 100%;
+  height: 153px;
+  display: flex;
+  gap: 24px;
+`;
+
+const Preview = styled.div`
+  display: flex;
+  width: 288px;
+  height: 153px;
+  justify-content: center;
+  align-items: center;
+  flex-shrink: 0;
+  border-radius: ${({ theme }) => theme.radius.large};
+  border: 1px solid ${({ theme }) => theme.color.neutralBorderDefault};
+`;
+
+const InputWrapper = styled.div`
+  width: 100%;
+  height: 153px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+const ColorSelector = styled.div`
+  display: flex;
+  gap: 24px;
+`;
+
+const BackgroundSelector = styled.div<{
+  $isFocus: boolean;
+  $isColorValid: boolean;
+}>`
+  display: flex;
+  height: 40px;
+  padding: 0px 16px;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+  border-radius: ${({ theme }) => theme.radius.medium};
+  background-color: ${({ theme, $isFocus }) =>
+    $isFocus ? "none" : theme.color.neutralSurfaceBold};
+  border: ${({ theme, $isFocus, $isColorValid }) =>
+    $isColorValid
+      ? $isFocus && `1px solid ${theme.color.neutralBorderDefaultActive}`
+      : `1px solid ${theme.color.dangerBorderDefault}`};
+
+  & > span {
+    width: 64px;
+    font: ${({ theme }) => theme.font.displayMedium12};
+    color: ${({ theme }) => theme.color.neutralTextWeak};
+  }
+
+  & > div {
+    width: 112px;
+    overflow: hidden;
+    font: ${({ theme }) => theme.font.displayMedium16};
+    color: ${({ theme }) => theme.color.neutralTextDefault};
+    text-overflow: ellipsis;
+  }
+`;
+
+const Buttons = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: right;
+  gap: 16px;
+`;

--- a/frontend/src/page/label/LabelEditor.tsx
+++ b/frontend/src/page/label/LabelEditor.tsx
@@ -21,7 +21,7 @@ type LabelEditorProps = {
 export function LabelEditor({ onClickClose, type, label }: LabelEditorProps) {
   const isEditMode = type === "edit" && label;
 
-  const [dropDownName, setDropDownName] = useState<string>(
+  const [selectedFontColor, setSelectedFontColor] = useState<string>(
     isEditMode ? colorDictionary[label.color] : "밝은 색",
   );
   const [background, setBackground] = useState(
@@ -36,7 +36,7 @@ export function LabelEditor({ onClickClose, type, label }: LabelEditorProps) {
   );
   const [isColorValid, setIsColorValid] = useState(true);
   const [isFocus, setIsFocus] = useState(false);
-  const [options, setOptions] = useState([
+  const [fontColorOptions, setFontColorOptions] = useState([
     {
       name: "밝은 색",
       profile: "",
@@ -69,9 +69,9 @@ export function LabelEditor({ onClickClose, type, label }: LabelEditorProps) {
     const fontColor = selectedName === "밝은 색" ? "LIGHT" : "DARK";
 
     setColor(fontColor);
-    setDropDownName(selectedName);
-    setOptions(
-      options.map((option) => {
+    setSelectedFontColor(selectedName);
+    setFontColorOptions(
+      fontColorOptions.map((option) => {
         return { ...option, selected: option.name === selectedName };
       }),
     );
@@ -104,7 +104,7 @@ export function LabelEditor({ onClickClose, type, label }: LabelEditorProps) {
   const onChangeName = (event: React.ChangeEvent<HTMLInputElement>) => {
     const name = event.target.value;
 
-    setLabelName(name);
+    setLabelName(name.trim());
   };
 
   const onChangeDescription = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -171,9 +171,9 @@ export function LabelEditor({ onClickClose, type, label }: LabelEditorProps) {
               </button>
             </BackgroundSelector>
             <DropdownContainer
-              name={dropDownName}
+              name={selectedFontColor}
               optionTitle={"텍스트 색상"}
-              options={options}
+              options={fontColorOptions}
               alignment="Left"
             />
           </ColorSelector>

--- a/frontend/src/page/label/LabelEditor.tsx
+++ b/frontend/src/page/label/LabelEditor.tsx
@@ -8,10 +8,10 @@ import { DropdownContainer } from "../../components/dropdown/DropdownContainer";
 import { LabelData } from "./Label";
 
 const colorDictionary = {
-  Light: "밝은 색",
-  Dark: "어두운 색",
-  "밝은 색": "Light",
-  "어두운 색": "Dark",
+  LIGHT: "밝은 색",
+  DARK: "어두운 색",
+  "밝은 색": "LIGHT",
+  "어두운 색": "DARK",
 };
 
 type LabelEditorProps = {
@@ -27,8 +27,8 @@ export function LabelEditor({ onClickClose, type, label }: LabelEditorProps) {
   const [background, setBackground] = useState(
     isEditMode ? label.background : "#000000",
   );
-  const [color, setColor] = useState<"Light" | "Dark">(
-    isEditMode ? label.color : "Light",
+  const [color, setColor] = useState<"LIGHT" | "DARK">(
+    isEditMode ? label.color : "LIGHT",
   );
   const [labelName, setLabelName] = useState(isEditMode ? label.name : "");
   const [labelDescription, setLabelDescription] = useState(
@@ -66,7 +66,7 @@ export function LabelEditor({ onClickClose, type, label }: LabelEditorProps) {
     : !isColorValid || labelName === "";
 
   const updateOptions = (selectedName: string) => {
-    const fontColor = selectedName === "밝은 색" ? "Light" : "Dark";
+    const fontColor = selectedName === "밝은 색" ? "LIGHT" : "DARK";
 
     setColor(fontColor);
     setDropDownName(selectedName);

--- a/frontend/src/page/label/LabelHeader.tsx
+++ b/frontend/src/page/label/LabelHeader.tsx
@@ -2,17 +2,23 @@ import { styled } from "styled-components";
 import { Button } from "../../components/Button";
 import { TabButton } from "../../components/TabButton";
 
+type LabelHeaderProps = {
+  onClick: () => void;
+  isAdding: boolean;
+  openedMilestoneCount: Number;
+  labelCount: Number;
+};
+
 export function LabelHeader({
   onClick,
   isAdding,
-}: {
-  onClick: () => void;
-  isAdding: boolean;
-}) {
+  openedMilestoneCount,
+  labelCount,
+}: LabelHeaderProps) {
   const tabs = [
-    { name: `label(5)`, icon: "label", selected: true },
+    { name: `label(${labelCount})`, icon: "label", selected: true },
     {
-      name: `milestone(2)`,
+      name: `milestone(${openedMilestoneCount})`,
       icon: "milestone",
       selected: false,
     },

--- a/frontend/src/page/label/LabelHeader.tsx
+++ b/frontend/src/page/label/LabelHeader.tsx
@@ -1,0 +1,58 @@
+import { styled } from "styled-components";
+import { Button } from "../../components/Button";
+import { TabButton } from "../../components/TabButton";
+
+export function LabelHeader({
+  onClick,
+  isAdding,
+}: {
+  onClick: () => void;
+  isAdding: boolean;
+}) {
+  const tabs = [
+    { name: `label(5)`, icon: "label", selected: true },
+    {
+      name: `milestone(2)`,
+      icon: "milestone",
+      selected: false,
+    },
+  ];
+
+  const onTabClick = () => {
+    console.log("click tab");
+  };
+
+  return (
+    <Div>
+      <TabButton onClick={onTabClick}>
+        {tabs.map(({ name, icon, selected }, index) => (
+          <Button
+            key={`tab-${index}`}
+            icon={icon}
+            size="M"
+            buttonType="Ghost"
+            flexible="Flexible"
+            selected={selected}
+          >
+            {name}
+          </Button>
+        ))}
+      </TabButton>
+      <Button
+        size="S"
+        buttonType="Container"
+        icon="plus"
+        onClick={onClick}
+        disabled={isAdding}
+      >
+        레이블 추가
+      </Button>
+    </Div>
+  );
+}
+
+const Div = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 24px;
+`;

--- a/frontend/src/page/label/LabelTable.tsx
+++ b/frontend/src/page/label/LabelTable.tsx
@@ -1,0 +1,42 @@
+import { styled } from "styled-components";
+import { LabelData } from "./Label";
+import { LabelTableElement } from "./LabelTableElement";
+
+export function LabelTable({ labels }: { labels: LabelData[] }) {
+  return (
+    <Div>
+      <TableHeader>{labels.length}개의 레이블</TableHeader>
+      <TableBody>
+        {labels.map((label, index) => (
+          <LabelTableElement key={index} label={label} />
+        ))}
+      </TableBody>
+    </Div>
+  );
+}
+
+const Div = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid ${({ theme }) => theme.color.neutralBorderDefault};
+  border-radius: ${({ theme }) => theme.radius.large};
+`;
+
+const TableHeader = styled.div`
+  display: flex;
+  height: 64px;
+  padding: 20px 32px;
+  box-sizing: border-box;
+  align-items: center;
+  align-self: stretch;
+  color: ${({ theme }) => theme.color.neutralTextDefault};
+  font: ${({ theme }) => theme.font.displayBold16};
+  background: ${({ theme }) => theme.color.neutralSurfaceDefault};
+  border-top-right-radius: ${({ theme }) => theme.radius.large};
+  border-top-left-radius: ${({ theme }) => theme.radius.large};
+`;
+
+const TableBody = styled.div`
+  width: 100%;
+`;

--- a/frontend/src/page/label/LabelTableElement.tsx
+++ b/frontend/src/page/label/LabelTableElement.tsx
@@ -1,0 +1,73 @@
+import { useState } from "react";
+import { styled } from "styled-components";
+import { Button } from "../../components/Button";
+import { InformationTag } from "../../components/InformationTag";
+import { LabelData } from "./Label";
+import { LabelEditor } from "./LabelEditor";
+
+export function LabelTableElement({ label }: { label: LabelData }) {
+  const [isEditing, setIsEditing] = useState(false);
+
+  const onClickEdit = () => {
+    setIsEditing(true);
+  };
+
+  const closeEditor = () => {
+    setIsEditing(false);
+  };
+
+  return isEditing ? (
+    <LabelEditor type="edit" label={label} onClickClose={closeEditor} />
+  ) : (
+    <Div>
+      <LabelTag>
+        <InformationTag
+          size="S"
+          value={label.name}
+          fill={label.background}
+          fontColor={label.color}
+        />
+      </LabelTag>
+      <Description>{label.description}</Description>
+      <Buttons>
+        <Button size="S" buttonType="Ghost" icon="edit" onClick={onClickEdit}>
+          편집
+        </Button>
+        <Button size="S" buttonType="Ghost" icon="trash">
+          삭제
+        </Button>
+      </Buttons>
+    </Div>
+  );
+}
+
+const Div = styled.div`
+  width: 100%;
+  min-height: 96px;
+  padding: 32px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 32px;
+  box-sizing: border-box;
+  border-top: solid 1px ${({ theme }) => theme.color.neutralBorderDefault};
+`;
+
+const Buttons = styled.div`
+  display: flex;
+  width: 106px;
+  align-items: flex-start;
+  gap: 24px;
+`;
+
+const Description = styled.span`
+  width: 870px;
+  display: flex;
+  font: ${({ theme }) => theme.font.displayMedium16};
+  color: ${({ theme }) => theme.color.neutralTextWeak};
+  flex: 1;
+`;
+
+const LabelTag = styled.div`
+  width: 96px;
+`;

--- a/frontend/src/page/label/LabelTableElement.tsx
+++ b/frontend/src/page/label/LabelTableElement.tsx
@@ -48,11 +48,6 @@ export function LabelTableElement({ label }: { label: LabelData }) {
   );
 }
 
-const Test = styled.div`
-  filter: invert(41%) sepia(88%) saturate(3066%) hue-rotate(337deg)
-    brightness(94%) contrast(116%);
-`;
-
 const Div = styled.div`
   width: 100%;
   min-height: 96px;

--- a/frontend/src/page/label/LabelTableElement.tsx
+++ b/frontend/src/page/label/LabelTableElement.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { styled } from "styled-components";
+import { styled, useTheme } from "styled-components";
 import { Button } from "../../components/Button";
 import { InformationTag } from "../../components/InformationTag";
 import { LabelData } from "./Label";
@@ -15,6 +15,8 @@ export function LabelTableElement({ label }: { label: LabelData }) {
   const closeEditor = () => {
     setIsEditing(false);
   };
+
+  const theme = useTheme();
 
   return isEditing ? (
     <LabelEditor type="edit" label={label} onClickClose={closeEditor} />
@@ -33,13 +35,23 @@ export function LabelTableElement({ label }: { label: LabelData }) {
         <Button size="S" buttonType="Ghost" icon="edit" onClick={onClickEdit}>
           편집
         </Button>
-        <Button size="S" buttonType="Ghost" icon="trash">
+        <Button
+          size="S"
+          buttonType="Ghost"
+          icon="trash"
+          color={theme.color.dangerSurfaceDefault}
+        >
           삭제
         </Button>
       </Buttons>
     </Div>
   );
 }
+
+const Test = styled.div`
+  filter: invert(41%) sepia(88%) saturate(3066%) hue-rotate(337deg)
+    brightness(94%) contrast(116%);
+`;
 
 const Div = styled.div`
   width: 100%;
@@ -55,7 +67,7 @@ const Div = styled.div`
 
 const Buttons = styled.div`
   display: flex;
-  width: 106px;
+  width: 130px;
   align-items: flex-start;
   gap: 24px;
 `;

--- a/frontend/src/page/main/MainHeader.tsx
+++ b/frontend/src/page/main/MainHeader.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
 import { styled } from "styled-components";
 
+import { useNavigate } from "react-router-dom";
 import { Button } from "../../components/Button";
 import { FilterBar } from "../../components/FilterBar";
 import { TabButton } from "../../components/TabButton";
@@ -17,14 +17,22 @@ export function MainHeader({
   milestoneCount,
   labelCount,
 }: MainHeaderProps) {
-  const [tabs, setTabs] = useState([
-    { name: `label(${labelCount})`, icon: "label", selected: false },
+  const navigate = useNavigate();
+
+  const tabs = [
+    {
+      name: `label(${labelCount})`,
+      icon: "label",
+      selected: false,
+      onClick: () => navigate("/label"),
+    },
     {
       name: `milestone(${milestoneCount})`,
       icon: "milestone",
       selected: false,
+      onClick: () => navigate("/milestone"),
     },
-  ]);
+  ];
 
   const setDropdownOptions = (singleFilters: SingleFilterData[]) => {
     const options = singleFilters.map((filter) => {
@@ -42,13 +50,9 @@ export function MainHeader({
   };
 
   const onTabClick = (name: string) => {
-    setTabs((t) =>
-      t.map((tab) =>
-        tab.name === name
-          ? { ...tab, selected: true }
-          : { ...tab, selected: false },
-      ),
-    );
+    const matchingTab = tabs.find((tab) => tab.name === name);
+
+    matchingTab && matchingTab.onClick();
   };
 
   return (


### PR DESCRIPTION
## Description
- label page 구현했습니다.
- 구현 과정에서 수정이 필요한 코드들 리팩토링 했습니다.

## Key Changes
### 라벨 메인
![캡처](https://github.com/masters2023-3rd-project-bugbusters/issue-tracker-max/assets/41321198/b06bda69-8bad-48f9-ac92-9b6460dd87c9)
### 라벨 추가
![캡처](https://github.com/masters2023-3rd-project-bugbusters/issue-tracker-max/assets/41321198/90ddd593-ef29-4574-9c46-ad3b0dd563bf)

- label page 구현햇습니다.
- /label, /milestone 라우트 설정 했습니다.
- 로고 클릭 시 / 로 이동하는 라우트 설정 했습니다.
- TextInput 컴포넌트에서 focus 관련 state 오류 수정했습니다.
  - focus 상태에서는 항상 하얀색 배경이어여 했지만 그렇지 못했습니다.
  - onChange 함수에 파라미터 event 추가했습니다
- Dropdown 컴포넌트가 높이 32px 이상의 부모에서는 가운데 정렬이 안되는 문제 수정했습니다.
  - container는 부모의 크기를 따라가지만 button의 크기는 32px 고정이라 가운데 정렬이 되지 않아 button의 높이 100%로 했습니다.
  - flex 속성을 사용하면 option들의 위치 조정이 힘들어 이렇게 수정했습니다.
- api 내에서 Light, Dark 상태를 모두 대문자로 관리하기로 했습니다.
  - 그래서 프론트에서도 모두 대문자로 수정했습니다.
  - Light -> LIGHT, Dark -> DARK
## To Reviewers
- LabelEditor 내용이 상당히 길고 가독성이 많이 떨어집니다.
  - 동작에는 아직 문제가 없다 판단되어 리팩토링은 진행하지 않았습니다.
  - 이번주 일정을 모두 소화한다면 리팩토링을 고려해 보겠습니다.
- Label에 들어가는 Button의 경우에 수정이 필요한 부분이 있습니다.
  - 가로 padding이 없는 경우가 필요합니다.
  - 원하는 색을 주입할 수 있어야 합니다. (삭제 버튼 빨간색)
- dropdown 옵션 클릭되면 Panel이 닫혀야 할 것 같습니다.
## Issue
- #69 
