### PR TITLE
[be] 이슈 DELETE API 구현

### DIFF
--- a/backend/src/main/java/codesquard/app/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/codesquard/app/comment/repository/CommentRepository.java
@@ -56,4 +56,8 @@ public class CommentRepository {
 		return id;
 	}
 
+	public void deleteByIssueId(Long issueId) {
+		String sql = "UPDATE comment SET is_deleted = true WHERE issue_id = :issueId";
+		template.update(sql, Map.of("issueId", issueId));
+	}
 }

--- a/backend/src/main/java/codesquard/app/issue/controller/IssueController.java
+++ b/backend/src/main/java/codesquard/app/issue/controller/IssueController.java
@@ -4,6 +4,7 @@ import javax.validation.Valid;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,6 +18,7 @@ import codesquard.app.issue.dto.request.IssueModifyMilestoneRequest;
 import codesquard.app.issue.dto.request.IssueModifyStatusRequest;
 import codesquard.app.issue.dto.request.IssueModifyTitleRequest;
 import codesquard.app.issue.dto.request.IssueSaveRequest;
+import codesquard.app.issue.dto.response.IssueDeleteResponse;
 import codesquard.app.issue.dto.response.IssueModifyResponse;
 import codesquard.app.issue.dto.response.IssueSaveResponse;
 import codesquard.app.issue.service.IssueService;
@@ -33,48 +35,54 @@ public class IssueController {
 		@Valid @RequestBody IssueSaveRequest issueSaveRequest) {
 		Long userId = 1L;
 		Long id = issueService.save(issueSaveRequest, userId);
-		return ResponseEntity.status(HttpStatus.CREATED).body(new IssueSaveResponse(true, id));
+		return ResponseEntity.status(HttpStatus.CREATED).body(IssueSaveResponse.success(id));
 	}
 
 	@PatchMapping("/api/issues/{issueId}/status")
 	public ResponseEntity<IssueModifyResponse> modifyStatus(
 		@RequestBody IssueModifyStatusRequest issueModifyStatusRequest, @PathVariable Long issueId) {
 		issueService.modifyStatus(issueModifyStatusRequest, issueId);
-		return ResponseEntity.status(HttpStatus.OK).body(new IssueModifyResponse(true));
+		return ResponseEntity.status(HttpStatus.OK).body(IssueModifyResponse.success());
 	}
 
 	@PatchMapping("/api/issues/{issueId}/title")
 	public ResponseEntity<IssueModifyResponse> modifyTitle(
 		@Valid @RequestBody IssueModifyTitleRequest issueModifyTitleRequest, @PathVariable Long issueId) {
 		issueService.modifyTitle(issueModifyTitleRequest, issueId);
-		return ResponseEntity.status(HttpStatus.OK).body(new IssueModifyResponse(true));
+		return ResponseEntity.status(HttpStatus.OK).body(IssueModifyResponse.success());
 	}
 
 	@PatchMapping("/api/issues/{issueId}/content")
 	public ResponseEntity<IssueModifyResponse> modifyContent(
 		@Valid @RequestBody IssueModifyContentRequest issueModifyContentRequest, @PathVariable Long issueId) {
 		issueService.modifyContent(issueModifyContentRequest, issueId);
-		return ResponseEntity.status(HttpStatus.OK).body(new IssueModifyResponse(true));
+		return ResponseEntity.status(HttpStatus.OK).body(IssueModifyResponse.success());
 	}
 
 	@PatchMapping("/api/issues/{issueId}/milestones")
 	public ResponseEntity<IssueModifyResponse> modifyMilestone(
 		@RequestBody IssueModifyMilestoneRequest issueModifyMilestoneRequest, @PathVariable Long issueId) {
 		issueService.modifyMilestone(issueModifyMilestoneRequest, issueId);
-		return ResponseEntity.status(HttpStatus.OK).body(new IssueModifyResponse(true));
+		return ResponseEntity.status(HttpStatus.OK).body(IssueModifyResponse.success());
 	}
 
 	@PatchMapping("/api/issues/{issueId}/assignees")
 	public ResponseEntity<IssueModifyResponse> modifyAssignees(
 		@RequestBody IssueModifyAssigneesRequest issueModifyAssigneesRequest, @PathVariable Long issueId) {
 		issueService.modifyAssignees(issueModifyAssigneesRequest, issueId);
-		return ResponseEntity.status(HttpStatus.OK).body(new IssueModifyResponse(true));
+		return ResponseEntity.status(HttpStatus.OK).body(IssueModifyResponse.success());
 	}
 
 	@PatchMapping("/api/issues/{issueId}/labels")
 	public ResponseEntity<IssueModifyResponse> modifyLabels(
 		@RequestBody IssueModifyLabelsRequest issueModifyLabelsRequest, @PathVariable Long issueId) {
 		issueService.modifyLabels(issueModifyLabelsRequest, issueId);
-		return ResponseEntity.status(HttpStatus.OK).body(new IssueModifyResponse(true));
+		return ResponseEntity.status(HttpStatus.OK).body(IssueModifyResponse.success());
+	}
+
+	@DeleteMapping("/api/issues/{issueId}")
+	public ResponseEntity<IssueDeleteResponse> delete(@PathVariable Long issueId) {
+		issueService.delete(issueId);
+		return ResponseEntity.status(HttpStatus.OK).body(IssueDeleteResponse.success());
 	}
 }

--- a/backend/src/main/java/codesquard/app/issue/dto/response/IssueDeleteResponse.java
+++ b/backend/src/main/java/codesquard/app/issue/dto/response/IssueDeleteResponse.java
@@ -1,0 +1,16 @@
+package codesquard.app.issue.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class IssueDeleteResponse {
+
+	@JsonProperty("success")
+	private final boolean success;
+
+	public static IssueDeleteResponse success() {
+		return new IssueDeleteResponse(true);
+	}
+}

--- a/backend/src/main/java/codesquard/app/issue/dto/response/IssueModifyResponse.java
+++ b/backend/src/main/java/codesquard/app/issue/dto/response/IssueModifyResponse.java
@@ -1,13 +1,16 @@
 package codesquard.app.issue.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class IssueModifyResponse {
 
+	@JsonProperty("success")
 	private final boolean success;
 
-	public boolean isSuccess() {
-		return success;
+	public static IssueModifyResponse success() {
+		return new IssueModifyResponse(true);
 	}
 }

--- a/backend/src/main/java/codesquard/app/issue/dto/response/IssueSaveResponse.java
+++ b/backend/src/main/java/codesquard/app/issue/dto/response/IssueSaveResponse.java
@@ -1,18 +1,18 @@
 package codesquard.app.issue.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class IssueSaveResponse {
 
+	@JsonProperty("success")
 	private final boolean success;
+	@JsonProperty("id")
 	private final Long id;
 
-	public boolean isSuccess() {
-		return success;
-	}
-
-	public Long getId() {
-		return id;
+	public static IssueSaveResponse success(Long id) {
+		return new IssueSaveResponse(true, id);
 	}
 }

--- a/backend/src/main/java/codesquard/app/issue/repository/IssueRepository.java
+++ b/backend/src/main/java/codesquard/app/issue/repository/IssueRepository.java
@@ -12,11 +12,11 @@ public interface IssueRepository {
 
 	List<Issue> findAll();
 
-	Issue findById(Long id);
+	Issue findBy(Long id);
 
 	Long modify(Issue issue);
 
-	void deleteById(Long id);
+	void deleteBy(Long id);
 
 	void saveIssueLabel(Long issueId, Long labelId);
 
@@ -30,13 +30,13 @@ public interface IssueRepository {
 
 	void modifyMilestone(Long milestoneId, Long issueId);
 
-	void deleteIssueAssigneesById(Long issueId);
+	void deleteIssueAssigneesBy(Long issueId);
 
-	void deleteIssueLabelsById(Long issueId);
+	void deleteIssueLabelsBy(Long issueId);
 
-	List<User> findAssigneesById(Long issueId);
+	List<User> findAssigneesBy(Long issueId);
 
-	List<Label> findLabelsById(Long issueId);
+	List<Label> findLabelsBy(Long issueId);
 
 	boolean exist(Long issueId);
 }

--- a/backend/src/main/java/codesquard/app/issue/repository/IssueRepository.java
+++ b/backend/src/main/java/codesquard/app/issue/repository/IssueRepository.java
@@ -16,7 +16,7 @@ public interface IssueRepository {
 
 	Long modify(Issue issue);
 
-	Long deleteById(Long id);
+	void deleteById(Long id);
 
 	void saveIssueLabel(Long issueId, Long labelId);
 
@@ -30,9 +30,9 @@ public interface IssueRepository {
 
 	void modifyMilestone(Long milestoneId, Long issueId);
 
-	void deleteAssigneesById(Long issueId);
+	void deleteIssueAssigneesById(Long issueId);
 
-	void deleteLabelsById(Long issueId);
+	void deleteIssueLabelsById(Long issueId);
 
 	List<User> findAssigneesById(Long issueId);
 

--- a/backend/src/main/java/codesquard/app/issue/repository/JdbcIssueRepository.java
+++ b/backend/src/main/java/codesquard/app/issue/repository/JdbcIssueRepository.java
@@ -63,7 +63,7 @@ public class JdbcIssueRepository implements IssueRepository {
 	}
 
 	@Override
-	public Issue findById(Long id) {
+	public Issue findBy(Long id) {
 		String sql = "SELECT id, title, content, status, status_modified_at, created_at, modified_at, milestone_id, "
 			+ "user_id, is_deleted FROM issue WHERE id = :id AND is_deleted = false";
 		return template.query(sql, Map.of("id", id), issueRowMapper).get(0);
@@ -75,7 +75,7 @@ public class JdbcIssueRepository implements IssueRepository {
 	}
 
 	@Override
-	public void deleteById(Long id) {
+	public void deleteBy(Long id) {
 		String sql = "UPDATE issue SET is_deleted = true WHERE id = :id";
 		template.update(sql, Map.of("id", id));
 	}
@@ -120,19 +120,19 @@ public class JdbcIssueRepository implements IssueRepository {
 	}
 
 	@Override
-	public void deleteIssueAssigneesById(Long issueId) {
+	public void deleteIssueAssigneesBy(Long issueId) {
 		String sql = "DELETE FROM issue_assignee WHERE issue_id = :issueId";
 		template.update(sql, Map.of("issueId", issueId));
 	}
 
 	@Override
-	public void deleteIssueLabelsById(Long issueId) {
+	public void deleteIssueLabelsBy(Long issueId) {
 		String sql = "DELETE FROM issue_label WHERE issue_id = :issueId";
 		template.update(sql, Map.of("issueId", issueId));
 	}
 
 	@Override
-	public List<User> findAssigneesById(Long issueId) {
+	public List<User> findAssigneesBy(Long issueId) {
 		String sql = "SELECT u.id, u.login_id, u.avatar_url FROM user as u "
 			+ "JOIN issue_assignee as ia ON ia.user_id = u.id "
 			+ "WHERE ia.issue_id = :issueId";
@@ -140,7 +140,7 @@ public class JdbcIssueRepository implements IssueRepository {
 	}
 
 	@Override
-	public List<Label> findLabelsById(Long issueId) {
+	public List<Label> findLabelsBy(Long issueId) {
 		String sql = "SELECT l.id, l.name, l.color, l.background FROM label as l "
 			+ "JOIN issue_label as il ON il.label_id = l.id "
 			+ "WHERE il.issue_id = :issueId";

--- a/backend/src/main/java/codesquard/app/issue/repository/JdbcIssueRepository.java
+++ b/backend/src/main/java/codesquard/app/issue/repository/JdbcIssueRepository.java
@@ -65,7 +65,7 @@ public class JdbcIssueRepository implements IssueRepository {
 	@Override
 	public Issue findById(Long id) {
 		String sql = "SELECT id, title, content, status, status_modified_at, created_at, modified_at, milestone_id, "
-			+ "user_id, is_deleted FROM issue WHERE id = :id";
+			+ "user_id, is_deleted FROM issue WHERE id = :id AND is_deleted = false";
 		return template.query(sql, Map.of("id", id), issueRowMapper).get(0);
 	}
 
@@ -75,8 +75,9 @@ public class JdbcIssueRepository implements IssueRepository {
 	}
 
 	@Override
-	public Long deleteById(Long id) {
-		return null;
+	public void deleteById(Long id) {
+		String sql = "UPDATE issue SET is_deleted = true WHERE id = :id";
+		template.update(sql, Map.of("id", id));
 	}
 
 	@Override
@@ -119,13 +120,13 @@ public class JdbcIssueRepository implements IssueRepository {
 	}
 
 	@Override
-	public void deleteAssigneesById(Long issueId) {
+	public void deleteIssueAssigneesById(Long issueId) {
 		String sql = "DELETE FROM issue_assignee WHERE issue_id = :issueId";
 		template.update(sql, Map.of("issueId", issueId));
 	}
 
 	@Override
-	public void deleteLabelsById(Long issueId) {
+	public void deleteIssueLabelsById(Long issueId) {
 		String sql = "DELETE FROM issue_label WHERE issue_id = :issueId";
 		template.update(sql, Map.of("issueId", issueId));
 	}
@@ -148,7 +149,7 @@ public class JdbcIssueRepository implements IssueRepository {
 
 	@Override
 	public boolean exist(Long issueId) {
-		String sql = "SELECT EXISTS (SELECT 1 FROM issue WHERE id = :id)";
+		String sql = "SELECT EXISTS (SELECT 1 FROM issue WHERE id = :id AND is_deleted = false)";
 		return Boolean.TRUE.equals(template.queryForObject(sql, Map.of("id", issueId), Boolean.class));
 	}
 }

--- a/backend/src/main/java/codesquard/app/issue/service/IssueService.java
+++ b/backend/src/main/java/codesquard/app/issue/service/IssueService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import codesquard.app.comment.repository.CommentRepository;
 import codesquard.app.errors.errorcode.IssueErrorCode;
 import codesquard.app.errors.exception.IllegalIssueStatusException;
 import codesquard.app.errors.exception.NoSuchIssueException;
@@ -27,6 +28,7 @@ import lombok.RequiredArgsConstructor;
 public class IssueService {
 
 	private final IssueRepository issueRepository;
+	private final CommentRepository commentRepository;
 
 	@Transactional
 	public Long save(IssueSaveRequest issueSaveRequest, Long userId) {
@@ -75,7 +77,7 @@ public class IssueService {
 	@Transactional
 	public void modifyAssignees(IssueModifyAssigneesRequest issueModifyAssigneesRequest, Long issueId) {
 		existIssue(issueId);
-		issueRepository.deleteAssigneesById(issueId);
+		issueRepository.deleteIssueAssigneesById(issueId);
 		registerIssueAssignee(issueId, issueModifyAssigneesRequest.getAssignees());
 	}
 
@@ -88,7 +90,7 @@ public class IssueService {
 	@Transactional
 	public void modifyLabels(IssueModifyLabelsRequest issueModifyLabelsRequest, Long issueId) {
 		existIssue(issueId);
-		issueRepository.deleteLabelsById(issueId);
+		issueRepository.deleteIssueLabelsById(issueId);
 		registerIssueLabel(issueId, issueModifyLabelsRequest.getLabels());
 	}
 
@@ -112,5 +114,12 @@ public class IssueService {
 		if (!issueRepository.exist(issueId)) {
 			throw new NoSuchIssueException(IssueErrorCode.NOT_FOUND_ISSUE);
 		}
+	}
+
+	@Transactional
+	public void delete(Long issueId) {
+		existIssue(issueId);
+		issueRepository.deleteById(issueId);
+		commentRepository.deleteByIssueId(issueId);
 	}
 }

--- a/backend/src/main/java/codesquard/app/issue/service/IssueService.java
+++ b/backend/src/main/java/codesquard/app/issue/service/IssueService.java
@@ -77,7 +77,7 @@ public class IssueService {
 	@Transactional
 	public void modifyAssignees(IssueModifyAssigneesRequest issueModifyAssigneesRequest, Long issueId) {
 		existIssue(issueId);
-		issueRepository.deleteIssueAssigneesById(issueId);
+		issueRepository.deleteIssueAssigneesBy(issueId);
 		registerIssueAssignee(issueId, issueModifyAssigneesRequest.getAssignees());
 	}
 
@@ -90,23 +90,23 @@ public class IssueService {
 	@Transactional
 	public void modifyLabels(IssueModifyLabelsRequest issueModifyLabelsRequest, Long issueId) {
 		existIssue(issueId);
-		issueRepository.deleteIssueLabelsById(issueId);
+		issueRepository.deleteIssueLabelsBy(issueId);
 		registerIssueLabel(issueId, issueModifyLabelsRequest.getLabels());
 	}
 
 	@Transactional(readOnly = true)
 	public Issue findById(Long issueId) {
-		return issueRepository.findById(issueId);
+		return issueRepository.findBy(issueId);
 	}
 
 	@Transactional(readOnly = true)
 	public List<User> findAssigneesById(Long issueId) {
-		return issueRepository.findAssigneesById(issueId);
+		return issueRepository.findAssigneesBy(issueId);
 	}
 
 	@Transactional(readOnly = true)
 	public List<Label> findLabelsById(Long issueId) {
-		return issueRepository.findLabelsById(issueId);
+		return issueRepository.findLabelsBy(issueId);
 	}
 
 	@Transactional
@@ -119,7 +119,7 @@ public class IssueService {
 	@Transactional
 	public void delete(Long issueId) {
 		existIssue(issueId);
-		issueRepository.deleteById(issueId);
+		issueRepository.deleteBy(issueId);
 		commentRepository.deleteByIssueId(issueId);
 	}
 }

--- a/backend/src/test/java/codesquard/app/comment/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/codesquard/app/comment/repository/CommentRepositoryTest.java
@@ -76,7 +76,6 @@ class CommentRepositoryTest extends IntegrationTestSupport {
 		assertThat(modifiedCommentId).isEqualTo(savedCommentId);
 	}
 
-
 	@DisplayName("등록된 댓글을 삭제한다.")
 	@Test
 	void test() {
@@ -93,7 +92,7 @@ class CommentRepositoryTest extends IntegrationTestSupport {
 	}
 
 	private void createUserFixture() {
-		User user = new User("yeon", "yeon@email.com", "password1000", "url path");
+		User user = new User(null, "yeon", "yeon@email.com", "password1000", "url path");
 		userRepository.save(user);
 	}
 

--- a/backend/src/test/java/codesquard/app/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/codesquard/app/comment/service/CommentServiceTest.java
@@ -125,7 +125,6 @@ class CommentServiceTest extends IntegrationTestSupport {
 			.hasMessage("댓글은 1자 이상 10000자 이하여야 합니다.");
 	}
 
-
 	@DisplayName("등록된 댓글을 삭제한다.")
 	@Test
 	void delete() {
@@ -142,7 +141,7 @@ class CommentServiceTest extends IntegrationTestSupport {
 	}
 
 	private void createUserFixture() {
-		User user = new User("yeon", "yeon@email.com", "password1000", "url path");
+		User user = new User(null, "yeon", "yeon@email.com", "password1000", "url path");
 		userRepository.save(user);
 	}
 

--- a/backend/src/test/java/codesquard/app/issue/controller/IssueControllerTest.java
+++ b/backend/src/test/java/codesquard/app/issue/controller/IssueControllerTest.java
@@ -279,6 +279,19 @@ class IssueControllerTest extends ControllerTestSupport {
 			.andDo(print());
 	}
 
+	@DisplayName("이슈를 삭제한다.")
+	@Test
+	void deleteIssue() throws Exception {
+		// given
+		int issueId = 1;
+
+		// when & then
+		mockMvc.perform(delete("/api/issues/" + issueId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andDo(print());
+	}
+
 	private String generateExceedingMaxLengthContent(int maxLength) {
 		StringBuilder builder = new StringBuilder();
 		while (builder.length() < maxLength) {

--- a/backend/src/test/java/codesquard/app/issue/fixture/FixtureFactory.java
+++ b/backend/src/test/java/codesquard/app/issue/fixture/FixtureFactory.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 import codesquard.app.issue.dto.request.IssueSaveRequest;
 import codesquard.app.milestone.dto.request.MilestoneSaveRequest;
-import codesquard.app.user.controller.request.UserSaveRequest;
+import codesquard.app.user.service.request.UserSaveServiceRequest;
 
 public class FixtureFactory {
 
@@ -16,12 +16,12 @@ public class FixtureFactory {
 		return new IssueSaveRequest(title, content, milestone, labels, assignees);
 	}
 
-	public static UserSaveRequest createUserSaveRequest() {
+	public static UserSaveServiceRequest createUserSaveServiceRequest() {
 		String userId = "wis";
 		String email = "wis@abcd.com";
 		String password = "code1234";
 		String avatarUrl = "url";
-		return new UserSaveRequest(userId, email, password, avatarUrl);
+		return new UserSaveServiceRequest(userId, email, password, password, avatarUrl);
 	}
 
 	public static MilestoneSaveRequest createMilestoneCreateRequest(String name) {

--- a/backend/src/test/java/codesquard/app/issue/repository/JdbcIssueRepositoryTest.java
+++ b/backend/src/test/java/codesquard/app/issue/repository/JdbcIssueRepositoryTest.java
@@ -78,7 +78,7 @@ class JdbcIssueRepositoryTest extends IntegrationTestSupport {
 		issueRepository.modifyStatus(issueStatus.name(), id);
 
 		// then
-		assertThat(issueRepository.findById(id).getStatus()).isEqualTo(issueStatus);
+		assertThat(issueRepository.findBy(id).getStatus()).isEqualTo(issueStatus);
 	}
 
 	@DisplayName("이슈를 등록하고 그 등록 번호의 이슈 제목을 수정한다.")
@@ -92,7 +92,7 @@ class JdbcIssueRepositoryTest extends IntegrationTestSupport {
 		issueRepository.modifyTitle(title, id);
 
 		// then
-		assertThat(issueRepository.findById(id).getTitle()).isEqualTo(title);
+		assertThat(issueRepository.findBy(id).getTitle()).isEqualTo(title);
 	}
 
 	@DisplayName("이슈를 등록하고 그 등록 번호의 이슈 내용을 수정한다.")
@@ -106,7 +106,7 @@ class JdbcIssueRepositoryTest extends IntegrationTestSupport {
 		issueRepository.modifyContent(content, id);
 
 		// then
-		assertThat(issueRepository.findById(id).getContent()).isEqualTo(content);
+		assertThat(issueRepository.findBy(id).getContent()).isEqualTo(content);
 	}
 
 	@DisplayName("이슈를 등록하고 그 등록 번호의 마일스톤을 수정한다.")
@@ -119,7 +119,7 @@ class JdbcIssueRepositoryTest extends IntegrationTestSupport {
 		issueRepository.modifyMilestone(null, id);
 
 		// then
-		assertThat(issueRepository.findById(id).getMilestoneId()).isEqualTo(0L);
+		assertThat(issueRepository.findBy(id).getMilestoneId()).isEqualTo(0L);
 	}
 
 	@DisplayName("이슈를 등록하고 삭제한다.")
@@ -129,7 +129,7 @@ class JdbcIssueRepositoryTest extends IntegrationTestSupport {
 		Long id = createIssue();
 
 		// when
-		issueRepository.deleteById(id);
+		issueRepository.deleteBy(id);
 
 		// then
 		assertThat(issueRepository.exist(id)).isFalse();

--- a/backend/src/test/java/codesquard/app/issue/repository/JdbcIssueRepositoryTest.java
+++ b/backend/src/test/java/codesquard/app/issue/repository/JdbcIssueRepositoryTest.java
@@ -122,8 +122,21 @@ class JdbcIssueRepositoryTest extends IntegrationTestSupport {
 		assertThat(issueRepository.findById(id).getMilestoneId()).isEqualTo(0L);
 	}
 
+	@DisplayName("이슈를 등록하고 삭제한다.")
+	@Test
+	void deleteIssue() {
+		// given
+		Long id = createIssue();
+
+		// when
+		issueRepository.deleteById(id);
+
+		// then
+		assertThat(issueRepository.exist(id)).isFalse();
+	}
+
 	private Long createIssue() {
-		Long loginId = userRepository.save(FixtureFactory.createUserSaveRequest().toEntity());
+		Long loginId = userRepository.save(FixtureFactory.createUserSaveServiceRequest().toEntity());
 		MilestoneSaveRequest milestoneSaveRequest = FixtureFactory.createMilestoneCreateRequest("레포지토리");
 		Long milestoneId = milestoneRepository.save(MilestoneSaveRequest.toEntity(milestoneSaveRequest)).orElseThrow();
 		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Repository", "내용", milestoneId);

--- a/backend/src/test/java/codesquard/app/issue/service/IssueServiceTest.java
+++ b/backend/src/test/java/codesquard/app/issue/service/IssueServiceTest.java
@@ -22,7 +22,7 @@ import codesquard.app.issue.dto.request.IssueModifyTitleRequest;
 import codesquard.app.issue.dto.request.IssueSaveRequest;
 import codesquard.app.issue.fixture.FixtureFactory;
 import codesquard.app.issue.repository.IssueRepository;
-import codesquard.app.label.dto.LabelSavedRequest;
+import codesquard.app.label.dto.LabelSaveRequest;
 import codesquard.app.label.entity.Label;
 import codesquard.app.label.service.LabelService;
 import codesquard.app.milestone.service.MilestoneService;
@@ -79,7 +79,7 @@ class IssueServiceTest extends IntegrationTestSupport {
 	@Test
 	void modifyStatus() {
 		// given
-		Long loginId = userService.save(FixtureFactory.createUserSaveRequest());
+		Long loginId = userRepository.save(FixtureFactory.createUserSaveServiceRequest().toEntity());
 		Long milestoneId = milestoneService.saveMilestone(FixtureFactory.createMilestoneCreateRequest("서비스"));
 		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Service", "내용", milestoneId);
 		Long id = issueService.save(issueSaveRequest, loginId);
@@ -112,7 +112,7 @@ class IssueServiceTest extends IntegrationTestSupport {
 	@Test
 	void modifyInvalidStatus_Response400() {
 		// given
-		Long loginId = userService.save(FixtureFactory.createUserSaveRequest());
+		Long loginId = userRepository.save(FixtureFactory.createUserSaveServiceRequest().toEntity());
 		Long milestoneId = milestoneService.saveMilestone(FixtureFactory.createMilestoneCreateRequest("서비스"));
 		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Service", "내용", milestoneId);
 		Long id = issueService.save(issueSaveRequest, loginId);
@@ -129,7 +129,7 @@ class IssueServiceTest extends IntegrationTestSupport {
 	@Test
 	void modifyTitle() {
 		// given
-		Long loginId = userService.save(FixtureFactory.createUserSaveRequest());
+		Long loginId = userRepository.save(FixtureFactory.createUserSaveServiceRequest().toEntity());
 		Long milestoneId = milestoneService.saveMilestone(FixtureFactory.createMilestoneCreateRequest("서비스"));
 		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Service", "내용", milestoneId);
 		Long id = issueService.save(issueSaveRequest, loginId);
@@ -148,7 +148,7 @@ class IssueServiceTest extends IntegrationTestSupport {
 	@Test
 	void modifyContent() {
 		// given
-		Long loginId = userService.save(FixtureFactory.createUserSaveRequest());
+		Long loginId = userRepository.save(FixtureFactory.createUserSaveServiceRequest().toEntity());
 		Long milestoneId = milestoneService.saveMilestone(FixtureFactory.createMilestoneCreateRequest("서비스"));
 		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Service", "내용", milestoneId);
 		Long id = issueService.save(issueSaveRequest, loginId);
@@ -167,7 +167,7 @@ class IssueServiceTest extends IntegrationTestSupport {
 	@Test
 	void modifyMilestone() {
 		// given
-		Long loginId = userService.save(FixtureFactory.createUserSaveRequest());
+		Long loginId = userRepository.save(FixtureFactory.createUserSaveServiceRequest().toEntity());
 		Long milestoneId1 = milestoneService.saveMilestone(FixtureFactory.createMilestoneCreateRequest("서비스"));
 		Long milestoneId2 = milestoneService.saveMilestone(FixtureFactory.createMilestoneCreateRequest("수정된 마일스톤"));
 		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Service", "내용", milestoneId1);
@@ -186,7 +186,7 @@ class IssueServiceTest extends IntegrationTestSupport {
 	@Test
 	void modifyAssignees() {
 		// given
-		Long loginId = userService.save(FixtureFactory.createUserSaveRequest());
+		Long loginId = userRepository.save(FixtureFactory.createUserSaveServiceRequest().toEntity());
 		Long milestoneId1 = milestoneService.saveMilestone(FixtureFactory.createMilestoneCreateRequest("서비스"));
 		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Service", "내용", milestoneId1);
 		Long id = issueService.save(issueSaveRequest, loginId);
@@ -204,12 +204,12 @@ class IssueServiceTest extends IntegrationTestSupport {
 	@Test
 	void modifyLabels() {
 		// given
-		Long loginId = userService.save(FixtureFactory.createUserSaveRequest());
+		Long loginId = userRepository.save(FixtureFactory.createUserSaveServiceRequest().toEntity());
 		Long milestoneId = milestoneService.saveMilestone(FixtureFactory.createMilestoneCreateRequest("서비스"));
 		String name = "feat";
 		String color = "light";
 		String background = "#111111";
-		Long labelId = labelService.saveLabel(new LabelSavedRequest(name, color, background, "기능 구현"));
+		Long labelId = labelService.saveLabel(new LabelSaveRequest(name, color, background, "기능 구현"));
 		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Service", "내용", milestoneId);
 		Long id = issueService.save(issueSaveRequest, loginId);
 
@@ -229,7 +229,7 @@ class IssueServiceTest extends IntegrationTestSupport {
 	@Test
 	void modifyLabels_Null() {
 		// given
-		Long loginId = userService.save(FixtureFactory.createUserSaveRequest());
+		Long loginId = userRepository.save(FixtureFactory.createUserSaveServiceRequest().toEntity());
 		Long milestoneId = milestoneService.saveMilestone(FixtureFactory.createMilestoneCreateRequest("서비스"));
 		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Service", "내용", milestoneId);
 		Long id = issueService.save(issueSaveRequest, loginId);
@@ -242,5 +242,21 @@ class IssueServiceTest extends IntegrationTestSupport {
 		// then
 		List<Label> label = issueService.findLabelsById(id);
 		assertThat(label).isEmpty();
+	}
+
+	@DisplayName("이슈를 삭제하고 같은 이슈를 삭제하면 NoSuchIssueException 발생한다.")
+	@Test
+	void delete() {
+		// given
+		Long loginId = userRepository.save(FixtureFactory.createUserSaveServiceRequest().toEntity());
+		Long milestoneId = milestoneService.saveMilestone(FixtureFactory.createMilestoneCreateRequest("서비스"));
+		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Service", "내용", milestoneId);
+		Long id = issueService.save(issueSaveRequest, loginId);
+
+		// when
+		issueService.delete(id);
+
+		// then
+		assertThatThrownBy(() -> issueService.delete(id)).isInstanceOf(NoSuchIssueException.class);
 	}
 }


### PR DESCRIPTION
## Description
- 이슈 soft-delete
- 해당 이슈 삭제 시 해당 이슈에 등록된 댓글도 함께 soft-delete 
- 삭제 전에 이슈가 존재하지 않는다면 NoSuchIssueException 발생
- 관련 테스트 코드 작성

## Next Step
- 이슈 상세 read API 구현