### PR TITLE
[fe] milestone page 구현 및 리팩토링 

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { designSystem } from "./constants/designSystem";
 import { Error404 } from "./page/Error404";
 import { Label } from "./page/label/Label";
 import { Main } from "./page/main/Main";
+import { Milestone } from "./page/milestone/Milestone";
 
 export default function App() {
   const [themeMode, setThemeMode] = useState<"LIGHT" | "DARK">("LIGHT");
@@ -18,6 +19,8 @@ export default function App() {
           <Routes>
             <Route path="/" element={<Main />} />
             <Route path="/label" element={<Label />} />
+            <Route path="/milestone" element={<Milestone />} />
+            <Route path="/milestone/:state" element={<Milestone />} />
             <Route path="*" element={<Error404 />} />
           </Routes>
         </Router>

--- a/frontend/src/components/TabButton.tsx
+++ b/frontend/src/components/TabButton.tsx
@@ -4,24 +4,16 @@ import { styled } from "styled-components";
 export function TabButton({
   type = "Outline",
   children,
-  onClick,
 }: {
   type?: "Ghost" | "Outline";
   children: ReactElement[];
-  onClick: (name: string) => void;
 }) {
   const TabButtonDiv =
     type === "Ghost" ? GhostTabButtonDiv : OutlineTabButtonDiv;
 
   return (
     <TabButtonDiv>
-      {Children.map(children, (child) =>
-        cloneElement(child, {
-          onClick: () => {
-            onClick(child.props.children);
-          },
-        }),
-      )}
+      {Children.map(children, (child) => cloneElement(child))}
     </TabButtonDiv>
   );
 }

--- a/frontend/src/components/TextInput.tsx
+++ b/frontend/src/components/TextInput.tsx
@@ -177,7 +177,7 @@ const IconWrapper = styled.div`
 `;
 
 const Input = styled.input<InputProps>`
-  width: 100%;
+  flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
   border: none;

--- a/frontend/src/components/TextInput.tsx
+++ b/frontend/src/components/TextInput.tsx
@@ -51,20 +51,12 @@ export function TextInput({
   const [state, setState] = useState<TextInputState>(
     disabled ? "Disabled" : "Enabled",
   );
-  const [inputValue, setInputValue] = useState(initialValue);
 
   useEffect(() => {
     setState(isError ? "Error" : "Enabled");
   }, [isError]);
 
-  useEffect(() => {
-    setInputValue(initialValue);
-  }, [initialValue]);
-
   const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const value = event.target.value;
-
-    setInputValue(value);
     onChange && onChange(event);
   };
 
@@ -95,7 +87,9 @@ export function TextInput({
         $state={state}
         $borderNone={borderNone}
       >
-        {(fixLabel || inputValue) && label && <StyledSpan>{label}</StyledSpan>}
+        {(fixLabel || initialValue) && label && (
+          <StyledSpan>{label}</StyledSpan>
+        )}
         {icon && (
           <IconWrapper>
             <Icon name={icon} fill={iconColor} stroke={iconColor} />
@@ -103,7 +97,7 @@ export function TextInput({
         )}
         <Input
           placeholder={placeholder}
-          value={inputValue}
+          value={initialValue}
           onChange={handleInputChange}
           onFocus={handleInputFocus}
           onBlur={handleInputBlur}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,5 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import App from './App.tsx'
-import './styles/index.css'
+import ReactDOM from "react-dom/client";
+import App from "./App.tsx";
+import "./styles/index.css";
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-)
+ReactDOM.createRoot(document.getElementById("root")!).render(<App />);

--- a/frontend/src/page/label/LabelHeader.tsx
+++ b/frontend/src/page/label/LabelHeader.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "react-router-dom";
 import { styled } from "styled-components";
 import { Button } from "../../components/Button";
 import { TabButton } from "../../components/TabButton";
@@ -15,23 +16,30 @@ export function LabelHeader({
   openedMilestoneCount,
   labelCount,
 }: LabelHeaderProps) {
+  const navigate = useNavigate();
   const tabs = [
-    { name: `label(${labelCount})`, icon: "label", selected: true },
+    {
+      name: `label(${labelCount})`,
+      icon: "label",
+      selected: true,
+      onClick: () => {
+        navigate("/label");
+      },
+    },
     {
       name: `milestone(${openedMilestoneCount})`,
       icon: "milestone",
       selected: false,
+      onClick: () => {
+        navigate("/milestone");
+      },
     },
   ];
 
-  const onTabClick = () => {
-    console.log("click tab");
-  };
-
   return (
     <Div>
-      <TabButton onClick={onTabClick}>
-        {tabs.map(({ name, icon, selected }, index) => (
+      <TabButton>
+        {tabs.map(({ name, icon, selected, onClick }, index) => (
           <Button
             key={`tab-${index}`}
             icon={icon}
@@ -39,6 +47,7 @@ export function LabelHeader({
             buttonType="Ghost"
             flexible="Flexible"
             selected={selected}
+            onClick={onClick}
           >
             {name}
           </Button>

--- a/frontend/src/page/main/MainHeader.tsx
+++ b/frontend/src/page/main/MainHeader.tsx
@@ -1,6 +1,5 @@
-import { styled } from "styled-components";
-
 import { useNavigate } from "react-router-dom";
+import { styled } from "styled-components";
 import { Button } from "../../components/Button";
 import { FilterBar } from "../../components/FilterBar";
 import { TabButton } from "../../components/TabButton";
@@ -66,7 +65,7 @@ export function MainHeader({
         />
       </div>
       <div style={{ display: "flex", gap: "16px" }}>
-        <TabButton onClick={onTabClick}>
+        <TabButton>
           {tabs.map(({ name, icon, selected }, index) => (
             <Button
               key={`tab-${index}`}
@@ -75,6 +74,7 @@ export function MainHeader({
               buttonType="Ghost"
               flexible="Flexible"
               selected={selected}
+              onClick={() => onTabClick(name)}
             >
               {name}
             </Button>

--- a/frontend/src/page/milestone/Milestone.tsx
+++ b/frontend/src/page/milestone/Milestone.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { styled } from "styled-components";
+import { MilestoneEditor } from "./MilestoneEditor";
+import { MilestoneHeader } from "./MilestoneHeader";
+import { MilestoneTable } from "./MilestoneTable";
+
+type IssueCounts = {
+  openedIssueCount: number;
+  closedIssueCount: number;
+};
+
+export type MilestoneData = {
+  id: number;
+  status: string;
+  name: string;
+  description: string;
+  createdAt: string;
+  modifiedAt: string | null;
+  deadline: string;
+  issues: IssueCounts;
+};
+
+type MilestonesResData = {
+  openedMilestoneCount: number;
+  closedMilestoneCount: number;
+  labelCount: number;
+  status: "OPENED" | "CLOSED";
+  milestones: MilestoneData[];
+};
+
+export function Milestone() {
+  const navigate = useNavigate();
+  const { state = "opened" } = useParams();
+
+  const [milestonesRes, setMilestonesRes] = useState<MilestonesResData>();
+  const [isAdding, setIsAdding] = useState(false);
+  useEffect(() => {
+    if (state !== "opened" && state !== "closed") {
+      navigate("/404");
+      return;
+    }
+
+    const fetchData = async () => {
+      const res = await fetch(
+        `https://8e24d81e-0591-4cf2-8200-546f93981656.mock.pstmn.io/api/milestones?state=${state}`,
+      );
+
+      setMilestonesRes(await res.json());
+    };
+
+    fetchData();
+  }, [state]);
+
+  const openAddMilestone = () => {
+    setIsAdding(true);
+  };
+
+  const closeAddLabel = () => {
+    setIsAdding(false);
+  };
+
+  return (
+    <Div>
+      {milestonesRes && (
+        <>
+          <MilestoneHeader
+            onClick={openAddMilestone}
+            isAdding={isAdding}
+            labelCount={milestonesRes.labelCount}
+            openedMilestoneCount={milestonesRes.openedMilestoneCount}
+          />
+          {isAdding && (
+            <EditorWrapper>
+              <MilestoneEditor onClickClose={closeAddLabel} type="add" />
+            </EditorWrapper>
+          )}
+          <MilestoneTable
+            milestones={milestonesRes.milestones}
+            openCount={milestonesRes.openedMilestoneCount}
+            closeCount={milestonesRes.closedMilestoneCount}
+            status={milestonesRes.status}
+          />
+        </>
+      )}
+    </Div>
+  );
+}
+
+const Div = styled.div`
+  width: 1280px;
+  display: flex;
+  flex-direction: column;
+`;
+
+const EditorWrapper = styled.div`
+  border: 1px solid ${({ theme }) => theme.color.neutralBorderDefault};
+  border-radius: ${({ theme }) => theme.radius.large};
+  margin-bottom: 24px;
+`;

--- a/frontend/src/page/milestone/MilestoneEditor.tsx
+++ b/frontend/src/page/milestone/MilestoneEditor.tsx
@@ -1,0 +1,190 @@
+import { useEffect, useState } from "react";
+import { styled } from "styled-components";
+import { Button } from "../../components/Button";
+import { TextInput } from "../../components/TextInput";
+import { MilestoneData } from "./Milestone";
+
+type MilestoneEditorProps = {
+  onClickClose: () => void;
+} & (
+  | { type: "add"; milestone?: never }
+  | { type: "edit"; milestone: MilestoneData }
+);
+
+export function MilestoneEditor({
+  onClickClose,
+  type,
+  milestone,
+}: MilestoneEditorProps) {
+  const isEditMode = type === "edit" && milestone;
+
+  const [milestoneName, setMilestoneName] = useState(
+    isEditMode ? milestone.name : "",
+  );
+  const [deadline, setDeadline] = useState(
+    isEditMode ? milestone.deadline : "",
+  );
+  const [description, setDescription] = useState(
+    isEditMode ? milestone.description : "",
+  );
+  const [isValidDeadline, setIsValidDeadline] = useState(true);
+
+  const [isButtonDisabled, setIsButtonDisabled] = useState(true);
+
+  useEffect(() => {
+    if (deadline === "") {
+      setIsValidDeadline(true);
+    } else {
+      const regex = /^(19|20)\d{2}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])$/;
+      setIsValidDeadline(regex.test(deadline));
+    }
+  }, [deadline]);
+
+  useEffect(() => {
+    const isMilestoneNameEmpty = milestoneName === "";
+
+    if (isEditMode) {
+      const isMilestoneChanged =
+        milestone.name !== milestoneName ||
+        milestone.deadline !== deadline ||
+        milestone.description !== description;
+
+      setIsButtonDisabled(
+        !isMilestoneChanged || isMilestoneNameEmpty || !isValidDeadline,
+      );
+    } else {
+      setIsButtonDisabled(isMilestoneNameEmpty || !isValidDeadline);
+    }
+  }, [milestoneName, deadline, description, isValidDeadline]);
+
+  const onChangeMilestoneName = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const value = event.target.value;
+
+    setMilestoneName(value.trim());
+  };
+
+  const onChangeDeadline = (event: React.ChangeEvent<HTMLInputElement>) => {
+    let value = event.target.value;
+    value = value.replace(/[^0-9]/g, "");
+
+    if (value.length < 5) {
+      value = value.replace(/(\d{4})/, "$1-");
+    } else if (value.length < 8) {
+      value = value.replace(/(\d{4})(\d{2})/, "$1-$2-");
+    } else {
+      value = value.replace(/(\d{4})(\d{2})(\d{2})/, "$1-$2-$3");
+    }
+
+    setDeadline(value);
+  };
+
+  const onChangeDescription = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+
+    setDescription(value.trim());
+  };
+
+  const submit = () => {
+    const obj = {
+      name: milestoneName,
+      description: description,
+      deadline: deadline,
+    };
+
+    console.log(obj);
+  };
+
+  return (
+    <Div>
+      <Title>{type === "add" ? "새로운 마일스톤 추가" : "마일스톤 편집"}</Title>
+      <Editor>
+        <Info>
+          <TextInput
+            width={600}
+            size="S"
+            label="이름"
+            value={milestoneName}
+            fixLabel
+            placeholder="마일스톤의 이름을 입력하세요."
+            onChange={onChangeMilestoneName}
+          />
+          <TextInput
+            width={600}
+            size="S"
+            label="완료일(선택)"
+            value={deadline}
+            fixLabel
+            placeholder="YYYY-MM-DD"
+            onChange={onChangeDeadline}
+            isError={!isValidDeadline}
+          />
+        </Info>
+        <TextInput
+          width={1216}
+          size="S"
+          label="설명(선택)"
+          value={description}
+          fixLabel
+          placeholder="마일스톤에 대한 설명을 입력하세요"
+          onChange={onChangeDescription}
+        />
+      </Editor>
+      <Buttons>
+        <Button
+          size="S"
+          icon="xSquare"
+          buttonType="Outline"
+          onClick={onClickClose}
+        >
+          취소
+        </Button>
+        <Button
+          size="S"
+          icon="plus"
+          buttonType="Container"
+          onClick={submit}
+          disabled={isButtonDisabled}
+        >
+          완료
+        </Button>
+      </Buttons>
+    </Div>
+  );
+}
+
+const Div = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  align-self: stretch;
+  box-sizing: border-box;
+  padding: 32px;
+  gap: 24px;
+`;
+
+const Title = styled.div`
+  font: ${({ theme }) => theme.font.displayBold20};
+  color: ${({ theme }) => theme.color.neutralTextStrong};
+`;
+
+const Editor = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+const Info = styled.div`
+  width: 100%;
+  display: flex;
+  gap: 16px;
+`;
+
+const Buttons = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: right;
+  gap: 16px;
+`;

--- a/frontend/src/page/milestone/MilestoneHeader.tsx
+++ b/frontend/src/page/milestone/MilestoneHeader.tsx
@@ -1,0 +1,73 @@
+import { useNavigate } from "react-router-dom";
+import { styled } from "styled-components";
+import { Button } from "../../components/Button";
+import { TabButton } from "../../components/TabButton";
+
+type MilestoneHeaderProps = {
+  onClick: () => void;
+  isAdding: boolean;
+  openedMilestoneCount: Number;
+  labelCount: Number;
+};
+
+export function MilestoneHeader({
+  onClick,
+  isAdding,
+  openedMilestoneCount,
+  labelCount,
+}: MilestoneHeaderProps) {
+  const navigate = useNavigate();
+  const tabs = [
+    {
+      name: `label(${labelCount})`,
+      icon: "label",
+      selected: false,
+      onClick: () => {
+        navigate("/label");
+      },
+    },
+    {
+      name: `milestone(${openedMilestoneCount})`,
+      icon: "milestone",
+      selected: true,
+      onClick: () => {
+        navigate("/milestone");
+      },
+    },
+  ];
+
+  return (
+    <Div>
+      <TabButton>
+        {tabs.map(({ name, icon, selected, onClick }, index) => (
+          <Button
+            key={`tab-${index}`}
+            icon={icon}
+            size="M"
+            buttonType="Ghost"
+            flexible="Flexible"
+            selected={selected}
+            onClick={onClick}
+          >
+            {name}
+          </Button>
+        ))}
+      </TabButton>
+      <Button
+        size="S"
+        buttonType="Container"
+        icon="plus"
+        onClick={onClick}
+        disabled={isAdding}
+      >
+        마일스톤 추가
+      </Button>
+    </Div>
+  );
+}
+
+const Div = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 24px;
+`;

--- a/frontend/src/page/milestone/MilestoneTable.tsx
+++ b/frontend/src/page/milestone/MilestoneTable.tsx
@@ -1,0 +1,98 @@
+import { useNavigate } from "react-router-dom";
+import { styled } from "styled-components";
+import { Button } from "../../components/Button";
+import { TabButton } from "../../components/TabButton";
+import { MilestoneData } from "./Milestone";
+import { MilestoneTableElement } from "./MilestoneTableElement";
+
+type MilestoneTableProps = {
+  milestones: MilestoneData[];
+  openCount: Number;
+  closeCount: Number;
+  status: "OPENED" | "CLOSED";
+};
+
+export function MilestoneTable({
+  milestones,
+  openCount,
+  closeCount,
+  status,
+}: MilestoneTableProps) {
+  const navigate = useNavigate();
+
+  const tabs = [
+    {
+      name: `열린 마일스톤(${openCount})`,
+      icon: "alertCircle",
+      selected: status === "OPENED",
+      onClick: () => {
+        navigate("/milestone/opened");
+      },
+    },
+    {
+      name: `닫힌 마일스톤(${closeCount})`,
+      icon: "archive",
+      selected: status === "CLOSED",
+      onClick: () => {
+        navigate("/milestone/closed");
+      },
+    },
+  ];
+
+  return (
+    <Div>
+      <TableHeader>
+        <TabButton type="Ghost">
+          {tabs.map(({ name, icon, selected, onClick }, index) => (
+            <Button
+              key={`tab-${index}`}
+              icon={icon}
+              size="M"
+              buttonType="Ghost"
+              flexible="Flexible"
+              selected={selected}
+              onClick={onClick}
+            >
+              {name}
+            </Button>
+          ))}
+        </TabButton>
+      </TableHeader>
+      <TableBody>
+        {milestones.map((milestone, index) => (
+          <MilestoneTableElement
+            key={index}
+            milestone={milestone}
+            status={status}
+          />
+        ))}
+      </TableBody>
+    </Div>
+  );
+}
+
+const Div = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid ${({ theme }) => theme.color.neutralBorderDefault};
+  border-radius: ${({ theme }) => theme.radius.large};
+`;
+
+const TableHeader = styled.div`
+  display: flex;
+  height: 64px;
+  padding: 20px 32px;
+  box-sizing: border-box;
+  align-items: center;
+  align-self: stretch;
+  color: ${({ theme }) => theme.color.neutralTextDefault};
+  font: ${({ theme }) => theme.font.displayBold16};
+  background: ${({ theme }) => theme.color.neutralSurfaceDefault};
+  border-top-right-radius: ${({ theme }) => theme.radius.large};
+  border-top-left-radius: ${({ theme }) => theme.radius.large};
+`;
+
+const TableBody = styled.div`
+  width: 100%;
+`;

--- a/frontend/src/page/milestone/MilestoneTableElement.tsx
+++ b/frontend/src/page/milestone/MilestoneTableElement.tsx
@@ -1,0 +1,203 @@
+import { useState } from "react";
+import { styled, useTheme } from "styled-components";
+import { Button } from "../../components/Button";
+import { Icon } from "../../components/Icon";
+import { MilestoneData } from "./Milestone";
+import { MilestoneEditor } from "./MilestoneEditor";
+
+export function MilestoneTableElement({
+  milestone,
+  status,
+}: {
+  milestone: MilestoneData;
+  status: "OPENED" | "CLOSED";
+}) {
+  const [isEditing, setIsEditing] = useState(false);
+
+  const onClickEdit = () => {
+    setIsEditing(true);
+  };
+
+  const closeEditor = () => {
+    setIsEditing(false);
+  };
+
+  const changeStatus = () => {
+    const id = milestone.id;
+
+    if (status === "OPENED") {
+      console.log(`close id: ${id}`);
+    } else {
+      console.log(`open id: ${id}`);
+    }
+  };
+
+  const deleteMilestone = () => {
+    const id = milestone.id;
+
+    console.log(`delete id: ${id}`);
+  };
+
+  const theme = useTheme();
+  const { issues } = milestone;
+  const totalIssueCount = issues.closedIssueCount + issues.openedIssueCount;
+
+  return (
+    <Div>
+      {isEditing ? (
+        <MilestoneEditor
+          onClickClose={closeEditor}
+          type="edit"
+          milestone={milestone}
+        />
+      ) : (
+        <>
+          <MilestoneInfo>
+            <div>
+              <Title>
+                <Icon
+                  name="milestone"
+                  fill={theme.color.paletteBlue}
+                  stroke={theme.color.paletteBlue}
+                />
+                <span>{milestone.name}</span>
+              </Title>
+              <Deadline>
+                <Icon
+                  name="calendar"
+                  fill={theme.color.neutralTextWeak}
+                  stroke={theme.color.neutralTextWeak}
+                />
+                <span>{milestone.deadline}</span>
+              </Deadline>
+            </div>
+            <Description>{milestone.description}</Description>
+          </MilestoneInfo>
+          <MilestoneProgress>
+            <Buttons>
+              <Button
+                size="S"
+                icon="archive"
+                buttonType="Ghost"
+                onClick={changeStatus}
+              >
+                {status === "OPENED" ? "닫기" : "열기"}
+              </Button>
+              <Button
+                size="S"
+                icon="edit"
+                buttonType="Ghost"
+                onClick={onClickEdit}
+              >
+                편집
+              </Button>
+              <Button
+                size="S"
+                icon="trash"
+                buttonType="Ghost"
+                color={theme.color.dangerSurfaceDefault}
+                onClick={deleteMilestone}
+              >
+                삭제
+              </Button>
+            </Buttons>
+            <Progress value={issues.closedIssueCount} max={totalIssueCount} />
+            <ProgressInfo>
+              <span>
+                {Math.floor((issues.closedIssueCount / totalIssueCount) * 100)}%
+              </span>
+              <span>
+                열린 이슈 {issues.openedIssueCount} 닫힌 이슈{" "}
+                {issues.closedIssueCount}
+              </span>
+            </ProgressInfo>
+          </MilestoneProgress>
+        </>
+      )}
+    </Div>
+  );
+}
+
+const Div = styled.div`
+  width: 100%;
+  min-height: 96px;
+  padding: 0 32px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  box-sizing: border-box;
+  border-top: solid 1px ${({ theme }) => theme.color.neutralBorderDefault};
+`;
+
+const MilestoneInfo = styled.div`
+  width: 932px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  & div {
+    display: flex;
+    gap: 16px;
+  }
+`;
+
+const Title = styled.div`
+  display: flex;
+  gap: 8px;
+
+  & span {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font: ${({ theme }) => theme.font.availableMedium16};
+    color: ${({ theme }) => theme.color.neutralTextStrong};
+  }
+`;
+
+const Deadline = styled.div`
+  display: flex;
+  gap: 8px;
+
+  & span {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font: ${({ theme }) => theme.font.displayMedium12};
+    color: ${({ theme }) => theme.color.neutralTextWeak};
+  }
+`;
+
+const Description = styled.span`
+  width: 870px;
+  display: flex;
+  font: ${({ theme }) => theme.font.displayMedium16};
+  color: ${({ theme }) => theme.color.neutralTextWeak};
+  flex: 1;
+`;
+const MilestoneProgress = styled.div`
+  width: 244px;
+  display: flex;
+  flex-direction: column;
+  align-items: end;
+`;
+
+const Buttons = styled.div`
+  width: 210px;
+  display: flex;
+  gap: 24px;
+`;
+
+const Progress = styled.progress`
+  width: 100%;
+`;
+
+const ProgressInfo = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+
+  & span {
+    font: ${({ theme }) => theme.font.displayMedium12};
+    color: ${({ theme }) => theme.color.neutralTextWeak};
+  }
+`;


### PR DESCRIPTION
## Description
- milestone page 구현 했습니다.
- 구현 과정에서 수정이 필요한 코드들 리팩토링 했습니다.

## Key Changes
### 마일스톤 메인
![캡처](https://github.com/masters2023-3rd-project-bugbusters/issue-tracker-max/assets/41321198/716c48c2-3367-4fe0-a102-11882bdecd0a)
### 마일스톤 추가/편집
![캡처](https://github.com/masters2023-3rd-project-bugbusters/issue-tracker-max/assets/41321198/ae4a041f-92dc-4628-88e2-f89003684dee)


- TabButton에서 하나의 onClick으로 이용해 Button에게 나눠 사용하던 과정이 불편하여 수정합니다.
  - 사용처에서 각각의 Button에게 onClick을 부여합니다.
- TextInput 에서 input이 생각한 크기보다 많이 차지하고 있어 수정했습니다.
- Textinput에 state가 필요 없을 것 같다고 말씀해 주신 부분 수정했습니다.
- StricMode 삭제했습니다.
  - api호출을 하고 너무 오래 걸려서 확인해 보니 api 호출을 2번하고 있어 느리다고 판단해 삭제했습니다.
- milestone 페이지 구현했습니다.

## To Reviewers
- Issue, label, milestone에 리스트가 80~90% 정도 비슷한 디자인으로 되어 있습니다.
  - 이 부분 공용으로 사용하면 코드의 크기가 많이 작아질 것 같습니다.
  - 그래서 리팩토링 고려하고 있습니다.
- label에서 너무 로직이 너무 복잡하고 더러워서 milestone은 깔끔하게 하려 노력했습니다.
- Issue, label, milestone에 데이터가 안 왔을 경우 데이터가 없다는 문구를 보여줘야 할 것 같은데 그런 예외 처리가 되어 있지 않습니다.
  - 다음 작업에 전체적인 리팩토링, 가독성 개선, api 연동 등 하며 추가할 예정입니다.

## Issues
- #83 
