### PR TITLE
[fe] TextInput이 관련 공용 컴포넌트 리팩토링

### DIFF
--- a/frontend/src/components/FilterBar.tsx
+++ b/frontend/src/components/FilterBar.tsx
@@ -1,14 +1,9 @@
 import { useState } from "react";
 import { styled } from "styled-components";
-import { TextInput } from "./TextInput";
+import { TextInput, TextInputProps } from "./TextInput";
 import { DropdownContainer } from "./dropdown/DropdownContainer";
 
-export function FilterBar({
-  name,
-  optionTitle,
-  options,
-  value,
-}: {
+type FilterBarProps = {
   name: string;
   optionTitle: string;
   options: {
@@ -17,8 +12,14 @@ export function FilterBar({
     selected: boolean;
     onClick: () => void;
   }[];
-  value: string;
-}) {
+} & TextInputProps;
+
+export function FilterBar({
+  name,
+  optionTitle,
+  options,
+  ...props
+}: FilterBarProps) {
   const [state, setState] = useState<"Enabled" | "Active">("Enabled");
 
   const handleFilterBarFocus = () => {
@@ -41,7 +42,7 @@ export function FilterBar({
         options={options}
         alignment="Left"
       />
-      <TextInput size="S" icon="Search" value={value} />
+      <TextInput icon="Search" {...props} />
     </Div>
   );
 }


### PR DESCRIPTION
## Description
issue main page 작업중 FilterBar에 있는 TextInput을 컨트롤 하는 과정과 props를 전달하는 과정이 불편하고 힘들었습니다.
그래서 TextInput 리팩토링 하며 TextInput을 사용하는 Filter도 함께 수정 했습니다.

## Key Changes
### TextInput
- TextInput props가 수정 되었습니다.
   ```ts
   // 수정 후
    export type TextInputProps = {
    size?: "L" | "S";
    label?: string;
    caption?: string;
    icon?: keyof IconType;
    fixLabel?: boolean;
    borderNone?: boolean;
    isError?: boolean;
  } & Omit<InputHTMLAttributes<HTMLInputElement>, "size">;
    ```
   - InputHTMLAttributes를 교차 타입으로 추가하며 기존에 input에 있는 속성들을 props에서 삭제했습니다.
   - size의 경우 "L" 과 "S"로 고정하기 위해 Omit으로 제외 했습니다.
- disabled 적용 안되는 현상 수정했습니다.
- width가 InputHTMLAttributes가 가지고 있는 기본 속성으로 바뀌며 string, number 모두 가능하게 했습니다.
  - 기존에는 number만 입력 가능했지만 수정 후 다음과 같이 입력 가능합니다
  ```ts
   <TextInput width={"100%"} />
   <TextInput width={"100px"} />
   <TextInput width={100} /> // 100px로 적용
  ```
  
### FilterBar
- 기존 FilterBar props type에 TextInputProps 를 교차 타입으로 지정 했습니다.
  ```ts
  type FilterBarProps = {
    name: string;
    optionTitle: string;
    options: {
      name: string;
      profile?: string;
      selected: boolean;
      onClick: () => void;
    }[];
  } & TextInputProps;

  //  사용처
  <TextInput icon="Search" {...props} />
  ```
- props를 이렇게 수정하면서 FilterBar를 사용하는 곳에서FilterBar 속에 있는 TextInput을 컨트롤할 props를 자유롭게 넘길 수 있습니다.

## To Reviewers
우선 최대한 TextInput 사용하는 컴포넌트에서 테스트 했습니다.
그래도 혹시 모르니 머지된다면 젤로가 작성하신 부분에 있는 TextInput이 제대로 작동하는지 테스트 부탁드립니다.

## Issue
- #131 