### PR TITLE
[fe] Sidebar 리팩토링 및 버그 수정

### DIFF
--- a/frontend/src/components/sidebar/Sidebar.tsx
+++ b/frontend/src/components/sidebar/Sidebar.tsx
@@ -99,7 +99,7 @@ export function Sidebar({
     }));
   };
 
-  const mapToData = <T extends ResponseData, U extends OptionData>(
+  const convertToOptionFormat = <T extends ResponseData, U extends OptionData>(
     data: T,
     multiSelect: boolean,
     setFunction: Dispatch<SetStateAction<U[]>>,
@@ -120,14 +120,16 @@ export function Sidebar({
     };
   };
 
-  const onDivHover = async <T extends OptionData, U extends ResponseData>(
+  const onMouseEnter = async <T extends OptionData, U extends ResponseData>(
     keyword: string,
     multiSelect: boolean,
     setFunction: Dispatch<SetStateAction<T[]>>,
     onClickCallback: (id: number) => void,
   ) => {
     const data = await fetchData(`${url}/api/${keyword}`);
-    const mappedData = data[keyword].map((d: U) => mapToData(d, multiSelect, setFunction, onClickCallback));
+    const mappedData = data[keyword].map((d: U) =>
+      convertToOptionFormat(d, multiSelect, setFunction, onClickCallback),
+    );
 
     setFunction(mappedData);
   };
@@ -143,7 +145,7 @@ export function Sidebar({
       <OptionDiv
         onMouseEnter={() =>
           !(assignees.length > 0) &&
-          onDivHover("assignees", true, setAssignees, onAssigneeClick)
+          onMouseEnter("assignees", true, setAssignees, onAssigneeClick)
         }
       >
         <DropdownContainer
@@ -165,7 +167,7 @@ export function Sidebar({
       <OptionDiv
         onMouseEnter={() => {
           !(labels.length > 0) &&
-            onDivHover("labels", true, setLabels, onLabelClick);
+            onMouseEnter("labels", true, setLabels, onLabelClick);
         }}
       >
         <DropdownContainer
@@ -193,7 +195,7 @@ export function Sidebar({
       <OptionDiv
         onMouseEnter={() => {
           !(milestones.length > 0) &&
-            onDivHover("milestones", false, setMilestones, onMilestoneClick);
+            onMouseEnter("milestones", false, setMilestones, onMilestoneClick);
         }}
       >
         <DropdownContainer

--- a/frontend/src/components/sidebar/Sidebar.tsx
+++ b/frontend/src/components/sidebar/Sidebar.tsx
@@ -37,16 +37,17 @@ type MilestoneData = {
 };
 
 type OptionData = AssigneeData | LabelData | MilestoneData;
+export type SidebarProps = {
+  onAssigneeClick: (id: number) => void;
+  onLabelClick: (id: number) => void;
+  onMilestoneClick: (id: number) => void;
+};
 
 export function Sidebar({
   onAssigneeClick,
   onLabelClick,
   onMilestoneClick,
-}: {
-  onAssigneeClick: (id: number) => void;
-  onLabelClick: (id: number) => void;
-  onMilestoneClick: (id: number) => void;
-}) {
+}: SidebarProps) {
   const [assignees, setAssignees] = useState<AssigneeData[]>([]);
   const [labels, setLabels] = useState<LabelData[]>([]);
   const [milestones, setMilestones] = useState<MilestoneData[]>([]);

--- a/frontend/src/page/newIssue/NewIssue.tsx
+++ b/frontend/src/page/newIssue/NewIssue.tsx
@@ -10,12 +10,16 @@ export function NewIssue() {
   const [milestone, setMilestone] = useState<number | null>(null);
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
+  const [invalidTitle, setInvalidTitle] = useState(false);
   const navigate = useNavigate();
 
-  const invalidTitle = title.trim().length === 0;
+  const onTitleFocus = () => {
+    setInvalidTitle(title.length === 0);
+  };
 
   const onTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTitle(e.target.value);
+    setInvalidTitle(e.target.value.length === 0);
   };
 
   const onContentChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -53,28 +57,7 @@ export function NewIssue() {
       milestone: milestone,
     };
 
-    try {
-      const response = await fetch(
-        "https://8e24d81e-0591-4cf2-8200-546f93981656.mock.pstmn.io/api/issues",
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify(issueData),
-        },
-      );
-      const data = await response.json();
-      if (!data.success) {
-        throw new Error(data.message);
-      }
-    } catch (error) {
-      throw new Error(
-        `${error} : 이슈를 등록하는 과정에서 오류가 발생했습니다.`,
-      );
-    } finally {
-      navigate("/");
-    }
+    console.log("이슈 등록 데이터", issueData);
   };
 
   const onCancelButtonClick = () => {
@@ -88,10 +71,12 @@ export function NewIssue() {
       <NewIssueBody
         title={title}
         content={content}
+        invalidTitle={invalidTitle}
         onAssigneeClick={onAssigneeClick}
         onLabelClick={onLabelClick}
         onMilestoneClick={onMilestoneClick}
         onTitleChange={onTitleChange}
+        onTitleFocus={onTitleFocus}
         onContentChange={onContentChange}
       />
       <Line />

--- a/frontend/src/page/newIssue/NewIssue.tsx
+++ b/frontend/src/page/newIssue/NewIssue.tsx
@@ -1,136 +1,18 @@
-import { useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { styled } from "styled-components";
-import { SidebarOptionData } from "../../components/sidebar/Sidebar";
 import { NewIssueBody } from "./NewIssueBody";
 import { NewIssueFooter } from "./NewIssueFooter";
 
-type AssigneeData = {
-  id: number;
-  loginId: string;
-  avatarUrl: string;
-  selected: boolean;
-};
-
-type LabelData = {
-  id: number;
-  name: string;
-  background: string;
-  color?: string;
-  description: string | null;
-  selected: boolean;
-};
-
-type MilestoneData = {
-  id: number;
-  name: string;
-  status: "OPENED" | "CLOSED";
-  description: string;
-  issues: {
-    openedIssueCount: number;
-    closedIssueCount: number;
-  };
-  selected: boolean;
-};
-
-export type OptionData = AssigneeData | LabelData | MilestoneData;
-
 export function NewIssue() {
-  const [assignees, setAssignees] = useState<AssigneeData[]>([]);
-  const [labels, setLabels] = useState<LabelData[]>([]);
-  const [milestones, setMilestones] = useState<MilestoneData[]>([]);
+  const [assignees, setAssignees] = useState<number[]>([]);
+  const [labels, setLabels] = useState<number[]>([]);
+  const [milestone, setMilestone] = useState<number | null>(null);
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
   const navigate = useNavigate();
 
-  useEffect(() => {
-    fetchSidebarOptions();
-  }, []);
-
-  const fetchSidebarOptions = async () => {
-    const url = "https://8e24d81e-0591-4cf2-8200-546f93981656.mock.pstmn.io";
-
-    const responses = await Promise.all([
-      fetch(`${url}/api/assignees`),
-      fetch(`${url}/api/labels`),
-      fetch(`${url}/api/milestones`),
-    ]);
-    const dataList = await Promise.all(
-      responses.map((response) => response.json()),
-    );
-
-    setAssignees(
-      dataList[0].assignees.map((assignee: AssigneeData) => ({
-        ...assignee,
-        selected: false,
-      })),
-    );
-    setLabels(
-      dataList[1].labels.map((label: LabelData) => ({
-        ...label,
-        selected: false,
-      })),
-    );
-    setMilestones(
-      dataList[2].milestones.map((milestone: MilestoneData) => ({
-        ...milestone,
-        selected: false,
-      })) ?? [],
-    );
-  };
-
   const invalidTitle = title.trim().length === 0;
-
-  const changeOptionSelection = <T extends OptionData>(
-    options: T[],
-    id: number,
-    multiple: boolean,
-  ) =>
-    options.map((option) => ({
-      ...option,
-      selected: multiple
-        ? option.id === id
-          ? !option.selected
-          : option.selected
-        : option.id === id,
-    }));
-
-  const createOptionsForSideBar = <T extends OptionData>(options: T[]) => {
-    return options.map((option) => {
-      if ("avatarUrl" in option) {
-        return {
-          id: option.id,
-          name: option.loginId,
-          profile: option.avatarUrl,
-          selected: option.selected,
-          onClick: () => {
-            setAssignees((a) => changeOptionSelection(a, option.id, true));
-          },
-        };
-      } else if ("background" in option) {
-        return {
-          id: option.id,
-          name: option.name,
-          background: option.background,
-          color: option.color,
-          selected: option.selected,
-          onClick: () => {
-            setLabels((a) => changeOptionSelection(a, option.id, true));
-          },
-        };
-      } else if ("issues" in option) {
-        return {
-          id: option.id,
-          name: option.name,
-          selected: option.selected,
-          issues: option.issues,
-          onClick: () => {
-            setMilestones((a) => changeOptionSelection(a, option.id, false));
-          },
-        };
-      }
-    }) as SidebarOptionData[];
-  };
 
   const onTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTitle(e.target.value);
@@ -140,17 +22,35 @@ export function NewIssue() {
     setContent(e.target.value);
   };
 
+  const onAssigneeClick = useCallback((id: number) => {
+    setAssignees((a) => {
+      if (a.includes(id)) {
+        return a.filter((a) => a !== id);
+      }
+      return [...a, id];
+    });
+  }, []);
+
+  const onLabelClick = useCallback((id: number) => {
+    setLabels((l) => {
+      if (l.includes(id)) {
+        return l.filter((l) => l !== id);
+      }
+      return [...l, id];
+    });
+  }, []);
+
+  const onMilestoneClick = useCallback((id: number) => {
+    setMilestone((m) => (m === id ? null : id));
+  }, []);
+
   const onSubmitButtonClick = async () => {
     const issueData = {
       title: title,
       content: content,
-      assignees: assignees
-        .filter((option) => option.selected)
-        .map((option) => option.id),
-      labels: labels
-        .filter((option) => option.selected)
-        .map((option) => option.id),
-      milestone: milestones?.find((option) => option.selected)?.id ?? null,
+      assignees: assignees,
+      labels: labels,
+      milestone: milestone,
     };
 
     try {
@@ -188,9 +88,9 @@ export function NewIssue() {
       <NewIssueBody
         title={title}
         content={content}
-        assignees={createOptionsForSideBar(assignees)}
-        labels={createOptionsForSideBar(labels)}
-        milestones={createOptionsForSideBar(milestones)}
+        onAssigneeClick={onAssigneeClick}
+        onLabelClick={onLabelClick}
+        onMilestoneClick={onMilestoneClick}
         onTitleChange={onTitleChange}
         onContentChange={onContentChange}
       />

--- a/frontend/src/page/newIssue/NewIssueBody.tsx
+++ b/frontend/src/page/newIssue/NewIssueBody.tsx
@@ -1,15 +1,15 @@
+import { useState } from "react";
 import { styled } from "styled-components";
 import { TextArea } from "../../components/TextArea";
 import { TextInput } from "../../components/TextInput";
-import { Sidebar, SidebarOptionData } from "../../components/sidebar/Sidebar";
-import { useState } from "react";
+import { Sidebar } from "../../components/sidebar/Sidebar";
 
 type NewIssueBodyProps = {
   title: string;
   content: string;
-  assignees: SidebarOptionData[];
-  labels: SidebarOptionData[];
-  milestones: SidebarOptionData[];
+  onAssigneeClick: (id: number) => void;
+  onLabelClick: (id: number) => void;
+  onMilestoneClick: (id: number) => void;
   onTitleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onContentChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
 };
@@ -17,9 +17,9 @@ type NewIssueBodyProps = {
 export function NewIssueBody({
   title,
   content,
-  assignees,
-  labels,
-  milestones,
+  onAssigneeClick,
+  onLabelClick,
+  onMilestoneClick,
   onTitleChange,
   onContentChange,
 }: NewIssueBodyProps) {
@@ -30,7 +30,9 @@ export function NewIssueBody({
 
   const onTitleFocus = () => {
     setInvalidTitle(title.length === 0);
-  }
+  };
+
+  // TODO: 제목 에레 상태 안 풀리는 현상 수정
 
   return (
     <Div>
@@ -59,9 +61,9 @@ export function NewIssueBody({
         />
       </NewIssueContent>
       <Sidebar
-        assigneeOptions={assignees}
-        labelOptions={labels}
-        milestoneOptions={milestones}
+        onAssigneeClick={onAssigneeClick}
+        onLabelClick={onLabelClick}
+        onMilestoneClick={onMilestoneClick}
       />
     </Div>
   );

--- a/frontend/src/page/newIssue/NewIssueBody.tsx
+++ b/frontend/src/page/newIssue/NewIssueBody.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { styled } from "styled-components";
 import { TextArea } from "../../components/TextArea";
 import { TextInput } from "../../components/TextInput";
@@ -7,27 +6,24 @@ import { Sidebar, SidebarProps } from "../../components/sidebar/Sidebar";
 type NewIssueBodyProps = {
   title: string;
   content: string;
+  invalidTitle: boolean;
   onTitleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onTitleFocus: () => void;
   onContentChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
 } & SidebarProps;
 
 export function NewIssueBody({
   title,
   content,
+  invalidTitle,
   onTitleChange,
+  onTitleFocus,
   onContentChange,
   ...props
 }: NewIssueBodyProps) {
-  const [invalidTitle, setInvalidTitle] = useState(false);
   const titleCaption = invalidTitle
     ? "제목은 1글자 이상 50글자 이하로 작성해주세요."
     : "";
-
-  const onTitleFocus = () => {
-    setInvalidTitle(title.length === 0);
-  };
-
-  // TODO: 제목 에레 상태 안 풀리는 현상 수정
 
   return (
     <Div>

--- a/frontend/src/page/newIssue/NewIssueBody.tsx
+++ b/frontend/src/page/newIssue/NewIssueBody.tsx
@@ -2,26 +2,21 @@ import { useState } from "react";
 import { styled } from "styled-components";
 import { TextArea } from "../../components/TextArea";
 import { TextInput } from "../../components/TextInput";
-import { Sidebar } from "../../components/sidebar/Sidebar";
+import { Sidebar, SidebarProps } from "../../components/sidebar/Sidebar";
 
 type NewIssueBodyProps = {
   title: string;
   content: string;
-  onAssigneeClick: (id: number) => void;
-  onLabelClick: (id: number) => void;
-  onMilestoneClick: (id: number) => void;
   onTitleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onContentChange: (e: React.ChangeEvent<HTMLTextAreaElement>) => void;
-};
+} & SidebarProps;
 
 export function NewIssueBody({
   title,
   content,
-  onAssigneeClick,
-  onLabelClick,
-  onMilestoneClick,
   onTitleChange,
   onContentChange,
+  ...props
 }: NewIssueBodyProps) {
   const [invalidTitle, setInvalidTitle] = useState(false);
   const titleCaption = invalidTitle
@@ -60,11 +55,7 @@ export function NewIssueBody({
           onChange={onContentChange}
         />
       </NewIssueContent>
-      <Sidebar
-        onAssigneeClick={onAssigneeClick}
-        onLabelClick={onLabelClick}
-        onMilestoneClick={onMilestoneClick}
-      />
+      <Sidebar {...props} />
     </Div>
   );
 }


### PR DESCRIPTION
## Description

- (기존 NewIssue에서 옵션 목록의 상태를 전부 관리하던 구조에서) Sidebar 자체적으로 목록을 요청하고 관리하는 구조로 변경

## Key Changes

- `Sidebar`에서 `Assignee`, `Label`, `Milestone` 목록을 요청합니다.
- 각각의 영역(드롭다운이 있는 영역)에 마우스를 올릴 때 비동기 요청을 보냅니다.
- NewIssue는 선택된 옵션들의 id 배열을 관리합니다.
  - 이 배열은 sidebar의 역할과는 무관합니다.
  - sidebar의 옵션에 selected가 있어서 이걸로 선택됐는지 아닌지 확인합니다.
- 이슈 제목을 입력해도 Error 상태에서 벗어나지 못하는 입력란을 수정하기 위해 Invalid 상태를 NewIssue에 두고 onTitleChange 때마다 상태 변경하도록 수정했습니다.

## To Reviewers

- NewIssueBody에서 Sidebar로 넘기기만 하는 props를 제거하기 위해 SidebarProps으로 교차타입 사용해봤습니다. 아주 간결해지는 것 같아 좋습니다.
- CRUD 기능 연동을 위해 fetch 커스텀 훅을 같이 작성해보는 것도 좋을 것 같습니다.

## Issues

- #126 

## Next Step

