### PR TITLE
[fe] Dropdown 추가 기능

### DIFF
--- a/frontend/src/components/FilterBar.tsx
+++ b/frontend/src/components/FilterBar.tsx
@@ -41,6 +41,7 @@ export function FilterBar({
         optionTitle={optionTitle}
         options={options}
         alignment="Left"
+        autoClose
       />
       <TextInput icon="Search" {...props} />
     </Div>

--- a/frontend/src/components/TextArea.tsx
+++ b/frontend/src/components/TextArea.tsx
@@ -269,6 +269,7 @@ const TextCount = styled.span<{ $hidden: boolean }>`
   align-self: flex-end;
   margin-right: 28px;
   font: ${({ theme }) => theme.font.displayMedium12};
+  color: ${({ theme }) => theme.color.neutralTextWeak};
   opacity: ${({ $hidden }) => ($hidden ? 0 : 1)};
   animation: ${({ $hidden }) => ($hidden ? fadeOut : fadeIn)} 0.2s ease-in-out;
 `;

--- a/frontend/src/components/dropdown/DropdownContainer.tsx
+++ b/frontend/src/components/dropdown/DropdownContainer.tsx
@@ -12,6 +12,7 @@ export function DropdownContainer({
   type = "Default",
   alignment,
   disabled = false,
+  autoClose = false
 }: {
   name: string;
   optionTitle: string;
@@ -26,6 +27,7 @@ export function DropdownContainer({
   type?: "Default" | "Long";
   alignment: "Left" | "Right" | "Center";
   disabled?: boolean;
+  autoClose?: boolean;
 }) {
   const [isPanelOpened, setIsPanelOpened] = useState(false);
 
@@ -53,6 +55,7 @@ export function DropdownContainer({
             showProfile={showProfile}
             alignment={alignment}
             options={options}
+            onOptionClick={autoClose ? closePanel : undefined}
           />
         </>
       )}

--- a/frontend/src/components/dropdown/DropdownPanel.tsx
+++ b/frontend/src/components/dropdown/DropdownPanel.tsx
@@ -7,6 +7,7 @@ export function DropdownPanel({
   alignment,
   optionTitle,
   options,
+  onOptionClick,
 }: {
   showProfile?: boolean;
   alignment: "Left" | "Right" | "Center";
@@ -18,6 +19,7 @@ export function DropdownPanel({
     selected: boolean;
     onClick: () => void;
   }[];
+  onOptionClick?: () => void;
 }) {
   return (
     <StyledPanel $alignment={alignment}>
@@ -31,7 +33,10 @@ export function DropdownPanel({
               profile={profile}
               background={background}
               selected={selected}
-              onClick={onClick}
+              onClick={() => {
+                onClick();
+                onOptionClick?.();
+              }}
             >
               {name}
             </DropdownOption>

--- a/frontend/src/components/dropdown/DropdownPanel.tsx
+++ b/frontend/src/components/dropdown/DropdownPanel.tsx
@@ -1,5 +1,5 @@
 import { css, styled } from "styled-components";
-import { IconColor } from "../icon/Icon";
+import { Icon, IconColor } from "../icon/Icon";
 import { DropdownOption } from "./DropdownOption";
 
 export function DropdownPanel({
@@ -21,28 +21,38 @@ export function DropdownPanel({
   }[];
   onOptionClick?: () => void;
 }) {
+  const renderOptions = () => {
+    if (options.length === 0) {
+      return (
+        <EmptyOption>
+          <Icon name="AlertCircle" color="dangerTextDefault" />
+          No Options
+        </EmptyOption>
+      );
+    }
+    return options.map(
+      ({ name, profile, background, selected, onClick }, index) => (
+        <DropdownOption
+          key={`dropdown-option-${index}`}
+          showProfile={showProfile}
+          profile={profile}
+          background={background}
+          selected={selected}
+          onClick={() => {
+            onClick();
+            onOptionClick?.();
+          }}
+        >
+          {name}
+        </DropdownOption>
+      ),
+    );
+  };
+
   return (
     <StyledPanel $alignment={alignment}>
       <div className="dropdown__header">{optionTitle}</div>
-      <ul>
-        {options.map(
-          ({ name, profile, background, selected, onClick }, index) => (
-            <DropdownOption
-              key={`dropdown-option-${index}`}
-              showProfile={showProfile}
-              profile={profile}
-              background={background}
-              selected={selected}
-              onClick={() => {
-                onClick();
-                onOptionClick?.();
-              }}
-            >
-              {name}
-            </DropdownOption>
-          ),
-        )}
-      </ul>
+      <ul>{renderOptions()}</ul>
     </StyledPanel>
   );
 }
@@ -96,4 +106,18 @@ const StyledPanel = styled.div<{ $alignment: "Left" | "Right" | "Center" }>`
       ${({ theme }) => `${theme.radius.large} ${theme.radius.large}`};
     background-color: ${({ theme }) => theme.color.neutralBorderDefault};
   }
+`;
+
+const EmptyOption = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-radius: ${({ theme }) =>
+    `0px 0px ${theme.radius.large} ${theme.radius.large}`};
+  font: ${({ theme }) => theme.font.availableMedium16};
+  font-style: italic;
+  background-color:  ${({ theme }) => theme.color.neutralSurfaceStrong};
+  color: ${({ theme }) => theme.color.dangerTextDefault};
 `;

--- a/frontend/src/components/dropdown/DropdownPanel.tsx
+++ b/frontend/src/components/dropdown/DropdownPanel.tsx
@@ -25,7 +25,7 @@ export function DropdownPanel({
     if (options.length === 0) {
       return (
         <EmptyOption>
-          <Icon name="AlertCircle" color="dangerTextDefault" />
+          <Icon name="AlertCircle" color="neutralTextDefault" />
           No Options
         </EmptyOption>
       );
@@ -119,5 +119,5 @@ const EmptyOption = styled.div`
   font: ${({ theme }) => theme.font.availableMedium16};
   font-style: italic;
   background-color:  ${({ theme }) => theme.color.neutralSurfaceStrong};
-  color: ${({ theme }) => theme.color.dangerTextDefault};
+  color: ${({ theme }) => theme.color.neutralTextDefault};
 `;

--- a/frontend/src/components/sidebar/Sidebar.tsx
+++ b/frontend/src/components/sidebar/Sidebar.tsx
@@ -205,6 +205,7 @@ export function Sidebar({
           options={milestones}
           type="Long"
           alignment="Center"
+          autoClose
         />
         {selectedMilestone && (
           <ElementContainer direction="Vertical">

--- a/frontend/src/page/label/LabelEditor.tsx
+++ b/frontend/src/page/label/LabelEditor.tsx
@@ -175,6 +175,7 @@ export function LabelEditor({ onClickClose, type, label }: LabelEditorProps) {
               optionTitle={"텍스트 색상"}
               options={fontColorOptions}
               alignment="Left"
+              autoClose
             />
           </ColorSelector>
         </InputWrapper>


### PR DESCRIPTION
## Description

- Dropdown 자동닫힘 기능, 옵션 없을 때의 UI 구현

## Key Changes

- DropdownContainer에 `autoClose` prop 추가
- autoClose prop에 따라서 DropdownPanel에 `onOptionClick`으로 다른 값을 전달한다.
- DropdownPanel에서 DropdownOption에 onClick 핸들러에서 onOptionClick을 호출한다.
- options 가 없으면 `No Options` 문구를 담은 요소 렌더링

## To Reviewers

- 드롭다운 자동닫힘 필요한 것 같은 곳을 우선 제가 적용해두긴 했습니다만, 추가적으로 필요한 곳이 있는지 살펴주세요.
  - DropdownContainer에 autoClose만 추가해주면 됩니다. (disabled 처럼)
- 빈 드롭다운 UI는 일단 임의대로 구현했습니다. 
  ![image](https://github.com/masters2023-3rd-project-bugbusters/issue-tracker-max/assets/60080167/3f090171-5fa7-4d47-88bd-75bd60eb76cd) ![image](https://github.com/masters2023-3rd-project-bugbusters/issue-tracker-max/assets/60080167/1172a803-32fb-4b45-a6b8-5054416f2d46)

## Issues

- #141 

## Next Step

다음 진행 사항
