### PR TITLE
[be] 사용자 반응 CREATE API 구현

### DIFF
--- a/backend/src/main/java/codesquard/app/api/errors/errorcode/IssueErrorCode.java
+++ b/backend/src/main/java/codesquard/app/api/errors/errorcode/IssueErrorCode.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 public enum IssueErrorCode implements ErrorCode {
 
 	INVALID_ISSUE_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 이슈 상태입니다."),
-	NOT_FOUND_ISSUE(HttpStatus.NOT_FOUND, "이슈를 찾을 수 없습니다.");
+	NOT_FOUND_ISSUE(HttpStatus.NOT_FOUND, "존재하지 않는 이슈입니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/backend/src/main/java/codesquard/app/api/errors/exception/NoSuchReactionException.java
+++ b/backend/src/main/java/codesquard/app/api/errors/exception/NoSuchReactionException.java
@@ -1,0 +1,10 @@
+package codesquard.app.api.errors.exception;
+
+public class NoSuchReactionException extends RuntimeException {
+
+	private static final String MESSAGE = "존재하지 않는 반응입니다.";
+
+	public NoSuchReactionException() {
+		super(MESSAGE);
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/errors/handler/UserReactionExceptionHandler.java
+++ b/backend/src/main/java/codesquard/app/api/errors/handler/UserReactionExceptionHandler.java
@@ -1,0 +1,28 @@
+package codesquard.app.api.errors.handler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import codesquard.app.api.errors.exception.NoSuchReactionException;
+import codesquard.app.api.response.ApiResponse;
+
+@RestControllerAdvice
+public class UserReactionExceptionHandler {
+
+	private static final Logger logger = LoggerFactory.getLogger(UserReactionExceptionHandler.class);
+
+	@ResponseStatus(HttpStatus.NOT_FOUND)
+	@ExceptionHandler(NoSuchReactionException.class)
+	public ApiResponse<Object> handleNoSuchReactionException(NoSuchReactionException e) {
+		logger.info("NoSuchReactionException handling : {}", e.toString());
+		return ApiResponse.of(
+			HttpStatus.NOT_FOUND,
+			e.getMessage(),
+			null
+		);
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/response/ResponseMessage.java
+++ b/backend/src/main/java/codesquard/app/api/response/ResponseMessage.java
@@ -5,6 +5,8 @@ public abstract class ResponseMessage {
 	public static final String COMMENT_SAVE_SUCCESS = "댓글 등록에 성공했습니다.";
 	public static final String ISSUE_SAVE_SUCCESS = "이슈 등록에 성공했습니다.";
 	public static final String IMAGE_SAVE_SUCCESS = "이미지 저장에 성공했습니다.";
+	public static final String USER_REACTION_ISSUE_SAVE_SUCCESS = "이슈 사용자 반응 등록에 성공했습니다.";
+	public static final String USER_REACTION_COMMENT_SAVE_SUCCESS = "댓글 사용자 반응 등록에 성공했습니다.";
 	public static final String MAXIMUM_UPLOAD_SIZE_EXCEEDED = "파일의 최대 크기를 초과했습니다.";
 	public static final String USER_SIGNUP_SUCCESS = "회원가입에 성공하였습니다.";
 	public static final String USER_LOGIN_SUCCESS = "로그인에 성공하였습니다.";

--- a/backend/src/main/java/codesquard/app/comment/service/CommentService.java
+++ b/backend/src/main/java/codesquard/app/comment/service/CommentService.java
@@ -54,7 +54,7 @@ public class CommentService {
 		}
 	}
 
-	private void validateCommentId(Long commentId) {
+	public void validateCommentId(Long commentId) {
 		if (!commentRepository.isExist(commentId)) {
 			throw new NoSuchCommentException();
 		}

--- a/backend/src/main/java/codesquard/app/user_reaction/controller/UserReactionController.java
+++ b/backend/src/main/java/codesquard/app/user_reaction/controller/UserReactionController.java
@@ -1,0 +1,42 @@
+package codesquard.app.user_reaction.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import codesquard.app.api.response.ApiResponse;
+import codesquard.app.api.response.ResponseMessage;
+import codesquard.app.user_reaction.dto.response.UserReactionSaveResponse;
+import codesquard.app.user_reaction.service.UserReactionService;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RequestMapping(path = "/api/reactions")
+@RestController
+public class UserReactionController {
+
+	private final UserReactionService userReactionService;
+
+	@ResponseStatus(HttpStatus.CREATED)
+	@PostMapping("/{reactionId}/issues/{issueId}")
+	public ApiResponse<UserReactionSaveResponse> saveIssueReaction(@PathVariable Long reactionId,
+		@PathVariable Long issueId) {
+		Long userId = 1L;
+		Long userReactionId = userReactionService.saveIssueReaction(reactionId, userId, issueId);
+		return ApiResponse.of(HttpStatus.CREATED, ResponseMessage.USER_REACTION_ISSUE_SAVE_SUCCESS,
+			UserReactionSaveResponse.success(userReactionId));
+	}
+
+	@ResponseStatus(HttpStatus.CREATED)
+	@PostMapping("/{reactionId}/comments/{commentId}")
+	public ApiResponse<UserReactionSaveResponse> saveCommentReaction(@PathVariable Long reactionId,
+		@PathVariable Long commentId) {
+		Long userId = 1L;
+		Long userReactionId = userReactionService.saveCommentReaction(reactionId, userId, commentId);
+		return ApiResponse.of(HttpStatus.CREATED, ResponseMessage.USER_REACTION_COMMENT_SAVE_SUCCESS,
+			UserReactionSaveResponse.success(userReactionId));
+	}
+}

--- a/backend/src/main/java/codesquard/app/user_reaction/dto/response/UserReactionSaveResponse.java
+++ b/backend/src/main/java/codesquard/app/user_reaction/dto/response/UserReactionSaveResponse.java
@@ -1,0 +1,16 @@
+package codesquard.app.user_reaction.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class UserReactionSaveResponse {
+
+	@JsonProperty("savedUserReactionId")
+	private final Long id;
+
+	public static UserReactionSaveResponse success(Long userReactionId) {
+		return new UserReactionSaveResponse(userReactionId);
+	}
+}

--- a/backend/src/main/java/codesquard/app/user_reaction/entity/UserReaction.java
+++ b/backend/src/main/java/codesquard/app/user_reaction/entity/UserReaction.java
@@ -1,0 +1,4 @@
+package codesquard.app.user_reaction.entity;
+
+public class UserReaction {
+}

--- a/backend/src/main/java/codesquard/app/user_reaction/repository/JdbcUserReactionRepository.java
+++ b/backend/src/main/java/codesquard/app/user_reaction/repository/JdbcUserReactionRepository.java
@@ -1,0 +1,57 @@
+package codesquard.app.user_reaction.repository;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Repository
+public class JdbcUserReactionRepository implements UserReactionRepository {
+
+	private final NamedParameterJdbcTemplate template;
+
+	@Override
+	public Long saveIssueReaction(Long reactionId, Long userId, Long issueId) {
+		KeyHolder keyHolder = new GeneratedKeyHolder();
+		String sql = "INSERT INTO user_reaction(reaction_id, user_id, issue_id) "
+			+ "VALUES(:reactionId, :userId, :issueId)";
+		template.update(sql, saveIssueParamSource(reactionId, userId, issueId), keyHolder);
+		return Objects.requireNonNull(keyHolder.getKey()).longValue();
+	}
+
+	@Override
+	public Long saveCommentReaction(Long reactionId, Long userId, Long commentId) {
+		KeyHolder keyHolder = new GeneratedKeyHolder();
+		String sql = "INSERT INTO user_reaction(reaction_id, user_id, comment_id) "
+			+ "VALUES(:reactionId, :userId, :commentId)";
+		template.update(sql, saveCommentParamSource(reactionId, userId, commentId), keyHolder);
+		return Objects.requireNonNull(keyHolder.getKey()).longValue();
+	}
+
+	@Override
+	public boolean isExist(Long reactionId) {
+		String sql = "SELECT EXISTS (SELECT 1 FROM reaction WHERE id = :id)";
+		return Boolean.TRUE.equals(template.queryForObject(sql, Map.of("id", reactionId), Boolean.class));
+	}
+
+	private MapSqlParameterSource saveIssueParamSource(Long reactionId, Long userId, Long issueId) {
+		return new MapSqlParameterSource()
+			.addValue("reactionId", reactionId)
+			.addValue("userId", userId)
+			.addValue("issueId", issueId);
+	}
+
+	private MapSqlParameterSource saveCommentParamSource(Long reactionId, Long userId, Long commentId) {
+		return new MapSqlParameterSource()
+			.addValue("reactionId", reactionId)
+			.addValue("userId", userId)
+			.addValue("commentId", commentId);
+	}
+}

--- a/backend/src/main/java/codesquard/app/user_reaction/repository/UserReactionRepository.java
+++ b/backend/src/main/java/codesquard/app/user_reaction/repository/UserReactionRepository.java
@@ -1,0 +1,9 @@
+package codesquard.app.user_reaction.repository;
+
+public interface UserReactionRepository {
+	Long saveIssueReaction(Long reactionId, Long userId, Long issueId);
+
+	Long saveCommentReaction(Long reactionId, Long userId, Long commentId);
+
+	boolean isExist(Long reactionId);
+}

--- a/backend/src/main/java/codesquard/app/user_reaction/service/UserReactionQueryService.java
+++ b/backend/src/main/java/codesquard/app/user_reaction/service/UserReactionQueryService.java
@@ -1,0 +1,22 @@
+package codesquard.app.user_reaction.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import codesquard.app.api.errors.exception.NoSuchReactionException;
+import codesquard.app.user_reaction.repository.UserReactionRepository;
+import lombok.RequiredArgsConstructor;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class UserReactionQueryService {
+
+	private final UserReactionRepository userReactionRepository;
+
+	public void validateExistReactionId(Long reactionId) {
+		if (!userReactionRepository.isExist(reactionId)) {
+			throw new NoSuchReactionException();
+		}
+	}
+}

--- a/backend/src/main/java/codesquard/app/user_reaction/service/UserReactionService.java
+++ b/backend/src/main/java/codesquard/app/user_reaction/service/UserReactionService.java
@@ -1,0 +1,32 @@
+package codesquard.app.user_reaction.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import codesquard.app.comment.service.CommentService;
+import codesquard.app.issue.service.IssueQueryService;
+import codesquard.app.user_reaction.repository.UserReactionRepository;
+import lombok.RequiredArgsConstructor;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class UserReactionService {
+
+	private final UserReactionRepository userReactionRepository;
+	private final UserReactionQueryService userReactionQueryService;
+	private final IssueQueryService issueQueryService;
+	private final CommentService commentService;
+
+	public Long saveIssueReaction(Long reactionId, Long userId, Long issueId) {
+		userReactionQueryService.validateExistReactionId(reactionId);
+		issueQueryService.validateExistIssue(issueId);
+		return userReactionRepository.saveIssueReaction(reactionId, userId, issueId);
+	}
+
+	public Long saveCommentReaction(Long reactionId, Long userId, Long commentId) {
+		userReactionQueryService.validateExistReactionId(reactionId);
+		commentService.validateCommentId(commentId);
+		return userReactionRepository.saveCommentReaction(reactionId, userId, commentId);
+	}
+}

--- a/backend/src/test/java/codesquard/app/ControllerTestSupport.java
+++ b/backend/src/test/java/codesquard/app/ControllerTestSupport.java
@@ -20,12 +20,15 @@ import codesquard.app.user.controller.UserRestController;
 import codesquard.app.user.service.AuthenticateUserService;
 import codesquard.app.user.service.UserQueryService;
 import codesquard.app.user.service.UserService;
+import codesquard.app.user_reaction.controller.UserReactionController;
+import codesquard.app.user_reaction.service.UserReactionService;
 
 @WebMvcTest(controllers = {
 	CommentController.class,
 	UserRestController.class,
 	IssueController.class,
-	LabelController.class
+	LabelController.class,
+	UserReactionController.class
 })
 @Import(value = {JwtProvider.class})
 public abstract class ControllerTestSupport {
@@ -59,4 +62,7 @@ public abstract class ControllerTestSupport {
 
 	@MockBean
 	protected AuthenticateUserService authenticateUserService;
+
+	@MockBean
+	protected UserReactionService userReactionService;
 }

--- a/backend/src/test/java/codesquard/app/issue/controller/IssueControllerTest.java
+++ b/backend/src/test/java/codesquard/app/issue/controller/IssueControllerTest.java
@@ -63,7 +63,8 @@ class IssueControllerTest extends ControllerTestSupport {
 	@Test
 	void create() throws Exception {
 		// given
-		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Controller", "내용", 1L);
+		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Controller", "내용", 1L,
+			anyLong());
 
 		// when & then
 		mockMvc.perform(post("/api/issues")
@@ -79,7 +80,7 @@ class IssueControllerTest extends ControllerTestSupport {
 	void create_InputZeroTitle_Response400() throws Exception {
 		// given
 		String zeroTitle = "";
-		IssueSaveRequest zero = FixtureFactory.createIssueRegisterRequest(zeroTitle, "내용", 1L);
+		IssueSaveRequest zero = FixtureFactory.createIssueRegisterRequest(zeroTitle, "내용", 1L, anyLong());
 
 		// when & then
 		mockMvc.perform(post("/api/issues")
@@ -95,7 +96,7 @@ class IssueControllerTest extends ControllerTestSupport {
 		// given
 		String title = generateExceedingMaxLengthContent(TITLE_MAX_LENGTH);
 
-		IssueSaveRequest over = FixtureFactory.createIssueRegisterRequest(title, "내용", 1L);
+		IssueSaveRequest over = FixtureFactory.createIssueRegisterRequest(title, "내용", 1L, anyLong());
 
 		// when & then
 		mockMvc.perform(post("/api/issues")
@@ -110,7 +111,7 @@ class IssueControllerTest extends ControllerTestSupport {
 	void create_InputBlankTitle_Response400() throws Exception {
 		// given
 		String blankTitle = " ";
-		IssueSaveRequest blank = FixtureFactory.createIssueRegisterRequest(blankTitle, "내용", 1L);
+		IssueSaveRequest blank = FixtureFactory.createIssueRegisterRequest(blankTitle, "내용", 1L, anyLong());
 
 		// when & then
 		mockMvc.perform(post("/api/issues")
@@ -126,7 +127,7 @@ class IssueControllerTest extends ControllerTestSupport {
 		// given
 		String content = generateExceedingMaxLengthContent(CONTENT_MAX_LENGTH);
 
-		IssueSaveRequest over = FixtureFactory.createIssueRegisterRequest("Controller", content, 1L);
+		IssueSaveRequest over = FixtureFactory.createIssueRegisterRequest("Controller", content, 1L, anyLong());
 
 		// when & then
 		mockMvc.perform(post("/api/issues")

--- a/backend/src/test/java/codesquard/app/issue/fixture/FixtureFactory.java
+++ b/backend/src/test/java/codesquard/app/issue/fixture/FixtureFactory.java
@@ -16,9 +16,10 @@ import codesquard.app.user.service.request.UserSaveServiceRequest;
 
 public class FixtureFactory {
 
-	public static IssueSaveRequest createIssueRegisterRequest(String title, String content, Long milestone) {
+	public static IssueSaveRequest createIssueRegisterRequest(String title, String content, Long milestone,
+		Long assigneeId) {
 		List<Long> labels = new ArrayList<>();
-		List<Long> assignees = List.of(1L);
+		List<Long> assignees = List.of(assigneeId);
 		return new IssueSaveRequest(title, content, milestone, labels, assignees);
 	}
 

--- a/backend/src/test/java/codesquard/app/issue/repository/JdbcIssueRepositoryTest.java
+++ b/backend/src/test/java/codesquard/app/issue/repository/JdbcIssueRepositoryTest.java
@@ -67,7 +67,8 @@ class JdbcIssueRepositoryTest extends IntegrationTestSupport {
 		MilestoneSaveRequest milestoneSaveRequest = FixtureFactory.createMilestoneCreateRequest("레포지토리");
 		Long milestoneId = milestoneRepository.save(MilestoneSaveRequest.toEntity(milestoneSaveRequest)).orElseThrow();
 
-		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Repository", "내용", milestoneId);
+		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Repository", "내용", milestoneId,
+			loginId);
 		Issue issue = issueSaveRequest.toEntity(loginId);
 
 		// when
@@ -151,7 +152,8 @@ class JdbcIssueRepositoryTest extends IntegrationTestSupport {
 		Long loginId = userRepository.save(FixtureFactory.createUserSaveServiceRequest().toEntity());
 		MilestoneSaveRequest milestoneSaveRequest = FixtureFactory.createMilestoneCreateRequest("레포지토리");
 		Long milestoneId = milestoneRepository.save(MilestoneSaveRequest.toEntity(milestoneSaveRequest)).orElseThrow();
-		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Repository", "내용", milestoneId);
+		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Repository", "내용", milestoneId,
+			loginId);
 		Issue issue = issueSaveRequest.toEntity(loginId);
 
 		Long id = issueRepository.save(issue);

--- a/backend/src/test/java/codesquard/app/issue/service/IssueServiceTest.java
+++ b/backend/src/test/java/codesquard/app/issue/service/IssueServiceTest.java
@@ -25,7 +25,6 @@ import codesquard.app.issue.dto.response.IssueReadResponse;
 import codesquard.app.issue.fixture.FixtureFactory;
 import codesquard.app.issue.repository.IssueRepository;
 import codesquard.app.label.dto.request.LabelSaveRequest;
-import codesquard.app.label.entity.Label;
 import codesquard.app.label.service.LabelService;
 import codesquard.app.milestone.service.MilestoneService;
 import codesquard.app.user.repository.UserRepository;
@@ -82,7 +81,8 @@ class IssueServiceTest extends IntegrationTestSupport {
 		// given
 		Long loginId = userRepository.save(FixtureFactory.createUserSaveServiceRequest().toEntity());
 		Long milestoneId = milestoneService.saveMilestone(FixtureFactory.createMilestoneCreateRequest("서비스"));
-		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Service", "내용", milestoneId);
+		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Service", "내용", milestoneId,
+			loginId);
 
 		// when
 		Long id = issueService.save(issueSaveRequest, loginId);
@@ -174,7 +174,8 @@ class IssueServiceTest extends IntegrationTestSupport {
 		Long loginId = userRepository.save(FixtureFactory.createUserSaveServiceRequest().toEntity());
 		Long milestoneId1 = milestoneService.saveMilestone(FixtureFactory.createMilestoneCreateRequest("서비스"));
 		Long milestoneId2 = milestoneService.saveMilestone(FixtureFactory.createMilestoneCreateRequest("수정된 마일스톤"));
-		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Service", "내용", milestoneId1);
+		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Service", "내용", milestoneId1,
+			loginId);
 		Long id = issueService.save(issueSaveRequest, loginId);
 
 		IssueModifyMilestoneRequest issueModifyMilestoneRequest = new IssueModifyMilestoneRequest(milestoneId2);
@@ -211,7 +212,8 @@ class IssueServiceTest extends IntegrationTestSupport {
 		String color = "light";
 		String background = "#111111";
 		Long labelId = labelService.saveLabel(new LabelSaveRequest(name, color, background, "기능 구현"));
-		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Service", "내용", milestoneId);
+		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Service", "내용", milestoneId,
+			loginId);
 		Long id = issueService.save(issueSaveRequest, loginId);
 
 		IssueModifyLabelsRequest issueModifyLabelsRequest = new IssueModifyLabelsRequest(List.of(labelId));
@@ -258,7 +260,8 @@ class IssueServiceTest extends IntegrationTestSupport {
 	private Long createIssue() {
 		Long loginId = userRepository.save(FixtureFactory.createUserSaveServiceRequest().toEntity());
 		Long milestoneId = milestoneService.saveMilestone(FixtureFactory.createMilestoneCreateRequest("서비스"));
-		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Service", "내용", milestoneId);
+		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Service", "내용", milestoneId,
+			loginId);
 		return issueService.save(issueSaveRequest, loginId);
 	}
 }

--- a/backend/src/test/java/codesquard/app/user_reaction/controller/UserReactionControllerTest.java
+++ b/backend/src/test/java/codesquard/app/user_reaction/controller/UserReactionControllerTest.java
@@ -1,0 +1,74 @@
+package codesquard.app.user_reaction.controller;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import codesquard.app.ControllerTestSupport;
+import codesquard.app.api.errors.exception.NoSuchReactionException;
+
+class UserReactionControllerTest extends ControllerTestSupport {
+
+	@DisplayName("이슈 사용자 반응을 등록한다.")
+	@Test
+	void createIssue() throws Exception {
+		// given
+		int reactionId = 1;
+		int issueId = 1;
+
+		// when & then
+		mockMvc.perform(post("/api/reactions/" + reactionId + "/issues/" + issueId))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.data.savedUserReactionId").exists())
+			.andDo(print());
+	}
+
+	@DisplayName("이슈 사용자 반응 등록에 실패한다.")
+	@Test
+	void createIssue_Fail() throws Exception {
+		// given
+		int reactionId = 1;
+		int issueId = 1;
+		willThrow(new NoSuchReactionException())
+			.given(userReactionService).saveIssueReaction(anyLong(), anyLong(), anyLong());
+
+		// when & then
+		mockMvc.perform(post("/api/reactions/" + reactionId + "/issues/" + issueId))
+			.andExpect(status().isNotFound())
+			.andDo(print());
+	}
+
+	@DisplayName("댓글 사용자 반응을 등록한다.")
+	@Test
+	void createComment() throws Exception {
+		// given
+		int reactionId = 1;
+		int commentId = 1;
+
+		// when & then
+		mockMvc.perform(post("/api/reactions/" + reactionId + "/comments/" + commentId))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.data.savedUserReactionId").exists())
+			.andDo(print());
+	}
+
+	@DisplayName("댓글 사용자 반응 등록에 실패한다.")
+	@Test
+	void createComment_Fail() throws Exception {
+		// given
+		int reactionId = 1;
+		int commentId = 1;
+		willThrow(new NoSuchReactionException())
+			.given(userReactionService).saveCommentReaction(anyLong(), anyLong(), anyLong());
+
+		// when & then
+		mockMvc.perform(post("/api/reactions/" + reactionId + "/comments/" + commentId))
+			.andExpect(status().isNotFound())
+			.andDo(print());
+	}
+}

--- a/backend/src/test/java/codesquard/app/user_reaction/repository/JdbcUserReactionRepositoryTest.java
+++ b/backend/src/test/java/codesquard/app/user_reaction/repository/JdbcUserReactionRepositoryTest.java
@@ -1,0 +1,88 @@
+package codesquard.app.user_reaction.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import codesquard.app.IntegrationTestSupport;
+import codesquard.app.comment.entity.Comment;
+import codesquard.app.comment.repository.CommentRepository;
+import codesquard.app.issue.dto.request.IssueSaveRequest;
+import codesquard.app.issue.entity.Issue;
+import codesquard.app.issue.fixture.FixtureFactory;
+import codesquard.app.issue.repository.IssueRepository;
+import codesquard.app.user.repository.UserRepository;
+
+class JdbcUserReactionRepositoryTest extends IntegrationTestSupport {
+
+	@Autowired
+	private UserReactionRepository userReactionRepository;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private IssueRepository issueRepository;
+	@Autowired
+	private CommentRepository commentRepository;
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.update("SET FOREIGN_KEY_CHECKS = 0");
+		jdbcTemplate.update("TRUNCATE TABLE issue_assignee");
+		jdbcTemplate.update("TRUNCATE TABLE issue_label");
+		jdbcTemplate.update("TRUNCATE TABLE issue");
+		jdbcTemplate.update("TRUNCATE TABLE milestone");
+		jdbcTemplate.update("TRUNCATE TABLE user");
+		jdbcTemplate.update("TRUNCATE TABLE label");
+		jdbcTemplate.update("TRUNCATE TABLE user_reaction");
+		jdbcTemplate.update("SET FOREIGN_KEY_CHECKS = 1");
+	}
+
+	@DisplayName("이슈 사용자 반응을 등록하고 그 등록 번호를 반환한다.")
+	@Test
+	void saveIssue() {
+		// given
+		Long loginId = userRepository.save(FixtureFactory.createUserSaveServiceRequest().toEntity());
+		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Repository", "내용", null,
+			loginId);
+		Issue issue = issueSaveRequest.toEntity(loginId);
+		Long issueId = issueRepository.save(issue);
+		issueRepository.saveIssueLabel(issueId, issueSaveRequest.getLabels());
+		issueRepository.saveIssueAssignee(issueId, issueSaveRequest.getAssignees());
+		Long reactionId = 1L;
+
+		// when
+		Long id = userReactionRepository.saveIssueReaction(reactionId, loginId, issueId);
+
+		// then
+		assertThat(id).isNotNull();
+	}
+
+	@DisplayName("댓글 사용자 반응을 등록하고 그 등록 번호를 반환한다.")
+	@Test
+	void saveComment() {
+		// given
+		Long loginId = userRepository.save(FixtureFactory.createUserSaveServiceRequest().toEntity());
+		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Repository", "내용", null,
+			loginId);
+		Issue issue = issueSaveRequest.toEntity(loginId);
+		Long issueId = issueRepository.save(issue);
+		issueRepository.saveIssueLabel(issueId, issueSaveRequest.getLabels());
+		issueRepository.saveIssueAssignee(issueId, issueSaveRequest.getAssignees());
+		Long reactionId = 1L;
+		Long commentId = commentRepository.save(new Comment(issueId, loginId, "댓글", LocalDateTime.now()));
+
+		// when
+		Long id = userReactionRepository.saveCommentReaction(reactionId, loginId, commentId);
+
+		// then
+		assertThat(id).isNotNull();
+	}
+}

--- a/backend/src/test/java/codesquard/app/user_reaction/service/UserReactionServiceTest.java
+++ b/backend/src/test/java/codesquard/app/user_reaction/service/UserReactionServiceTest.java
@@ -1,0 +1,139 @@
+package codesquard.app.user_reaction.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import codesquard.app.IntegrationTestSupport;
+import codesquard.app.api.errors.exception.NoSuchCommentException;
+import codesquard.app.api.errors.exception.NoSuchIssueException;
+import codesquard.app.api.errors.exception.NoSuchReactionException;
+import codesquard.app.comment.service.CommentService;
+import codesquard.app.comment.service.request.CommentSaveServiceRequest;
+import codesquard.app.issue.dto.request.IssueSaveRequest;
+import codesquard.app.issue.fixture.FixtureFactory;
+import codesquard.app.issue.service.IssueService;
+import codesquard.app.user.repository.UserRepository;
+
+class UserReactionServiceTest extends IntegrationTestSupport {
+
+	@Autowired
+	private UserReactionService userReactionService;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private IssueService issueService;
+	@Autowired
+	private CommentService commentService;
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.update("SET FOREIGN_KEY_CHECKS = 0");
+		jdbcTemplate.update("TRUNCATE TABLE issue_assignee");
+		jdbcTemplate.update("TRUNCATE TABLE issue_label");
+		jdbcTemplate.update("TRUNCATE TABLE issue");
+		jdbcTemplate.update("TRUNCATE TABLE milestone");
+		jdbcTemplate.update("TRUNCATE TABLE user");
+		jdbcTemplate.update("TRUNCATE TABLE label");
+		jdbcTemplate.update("TRUNCATE TABLE user_reaction");
+		jdbcTemplate.update("SET FOREIGN_KEY_CHECKS = 1");
+	}
+
+	@DisplayName("이슈 사용자 반응을 등록한다.")
+	@Test
+	void createIssue() {
+		// given
+		Long loginId = userRepository.save(FixtureFactory.createUserSaveServiceRequest().toEntity());
+		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Service", "내용", null, loginId);
+		Long issueId = issueService.save(issueSaveRequest, loginId);
+		Long reactionId = 1L;
+
+		// when
+		Long id = userReactionService.saveIssueReaction(reactionId, loginId, issueId);
+
+		// then
+		assertThat(id).isNotNull();
+	}
+
+	@DisplayName("반응이 존재하지 않아 이슈 사용자 반응 등록에 실패한다.")
+	@Test
+	void createIssue_NoSuchReactionException() {
+		// given
+		Long loginId = userRepository.save(FixtureFactory.createUserSaveServiceRequest().toEntity());
+		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Service", "내용", null, loginId);
+		Long issueId = issueService.save(issueSaveRequest, loginId);
+		Long reactionId = 10000L;
+
+		// when & then
+		assertThatThrownBy(() -> userReactionService.saveIssueReaction(reactionId, loginId, issueId)).isInstanceOf(
+			NoSuchReactionException.class);
+	}
+
+	@DisplayName("이슈가 존재하지 않아 이슈 사용자 반응 등록에 실패한다.")
+	@Test
+	void createIssue_NoSuchIssueException() {
+		// given
+		Long loginId = userRepository.save(FixtureFactory.createUserSaveServiceRequest().toEntity());
+		Long issueId = 10000L;
+		Long reactionId = 1L;
+
+		// when & then
+		assertThatThrownBy(() -> userReactionService.saveIssueReaction(reactionId, loginId, issueId)).isInstanceOf(
+			NoSuchIssueException.class);
+	}
+
+	@DisplayName("댓글 사용자 반응을 등록한다.")
+	@Test
+	void createComment() {
+		// given
+		Long loginId = userRepository.save(FixtureFactory.createUserSaveServiceRequest().toEntity());
+		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Service", "내용", null, loginId);
+		Long issueId = issueService.save(issueSaveRequest, loginId);
+		CommentSaveServiceRequest commentSaveServiceRequest = new CommentSaveServiceRequest(issueId, loginId, "댓글");
+		Long commentId = commentService.save(commentSaveServiceRequest, LocalDateTime.now()).getSavedCommentId();
+		Long reactionId = 1L;
+
+		// when
+		Long id = userReactionService.saveCommentReaction(reactionId, loginId, commentId);
+
+		// then
+		assertThat(id).isNotNull();
+	}
+
+	@DisplayName("반응이 존재하지 않아 댓글 사용자 반응 등록에 실패한다.")
+	@Test
+	void createComment_NoSuchReactionException() {
+		// given
+		Long loginId = userRepository.save(FixtureFactory.createUserSaveServiceRequest().toEntity());
+		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Service", "내용", null, loginId);
+		Long issueId = issueService.save(issueSaveRequest, loginId);
+		CommentSaveServiceRequest commentSaveServiceRequest = new CommentSaveServiceRequest(issueId, loginId, "댓글");
+		Long commentId = commentService.save(commentSaveServiceRequest, LocalDateTime.now()).getSavedCommentId();
+		Long reactionId = 10000L;
+
+		// when & then
+		assertThatThrownBy(() -> userReactionService.saveCommentReaction(reactionId, loginId, commentId)).isInstanceOf(
+			NoSuchReactionException.class);
+	}
+
+	@DisplayName("반응이 존재하지 않아 댓글 사용자 반응 등록에 실패한다.")
+	@Test
+	void createComment_NoSuchCommentException() {
+		// given
+		Long loginId = userRepository.save(FixtureFactory.createUserSaveServiceRequest().toEntity());
+		Long commentId = 10000L;
+		Long reactionId = 1L;
+
+		// when & then
+		assertThatThrownBy(() -> userReactionService.saveCommentReaction(reactionId, loginId, commentId)).isInstanceOf(
+			NoSuchCommentException.class);
+	}
+}


### PR DESCRIPTION
## Description

- 이슈 사용자 반응 등록 API
- 댓글 사용자 반응 등록 API
- 테스트 코드 작성
- 예외 처리
  - 이슈가 존재하지 않을 경우
  - 댓글이 존재하지 않을 경우
  - 반응이 존재하지 않을 경우

## Next Step

- 사용자 반응 삭제 구현
