### PR TITLE
[be] 이슈 수정시간 추가 로직 구현

### DIFF
--- a/backend/src/main/java/codesquard/app/issue/controller/IssueController.java
+++ b/backend/src/main/java/codesquard/app/issue/controller/IssueController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import codesquard.app.api.response.ApiResponse;
 import codesquard.app.api.response.ResponseMessage;
+import codesquard.app.authenticate_user.entity.AuthenticateUser;
 import codesquard.app.issue.dto.request.IssueModifyAssigneesRequest;
 import codesquard.app.issue.dto.request.IssueModifyContentRequest;
 import codesquard.app.issue.dto.request.IssueModifyLabelsRequest;
@@ -28,6 +29,7 @@ import codesquard.app.issue.dto.response.IssueReadResponse;
 import codesquard.app.issue.dto.response.IssueSaveResponse;
 import codesquard.app.issue.service.IssueQueryService;
 import codesquard.app.issue.service.IssueService;
+import codesquard.app.user.annotation.Login;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -46,8 +48,8 @@ public class IssueController {
 	@ResponseStatus(HttpStatus.CREATED)
 	@PostMapping
 	public ApiResponse<IssueSaveResponse> save(
-		@Valid @RequestBody IssueSaveRequest issueSaveRequest) {
-		Long userId = 1L;
+		@Valid @RequestBody IssueSaveRequest issueSaveRequest, @Login AuthenticateUser user) {
+		Long userId = user.toEntity().getId();
 		Long issueId = issueService.save(issueSaveRequest, userId);
 		return ApiResponse.of(HttpStatus.CREATED, ResponseMessage.ISSUE_SAVE_SUCCESS,
 			IssueSaveResponse.success(issueId));

--- a/backend/src/main/java/codesquard/app/issue/dto/response/IssueReadResponse.java
+++ b/backend/src/main/java/codesquard/app/issue/dto/response/IssueReadResponse.java
@@ -60,6 +60,14 @@ public class IssueReadResponse {
 		return status;
 	}
 
+	public LocalDateTime getStatusModifiedAt() {
+		return statusModifiedAt;
+	}
+
+	public LocalDateTime getModifiedAt() {
+		return modifiedAt;
+	}
+
 	public String getContent() {
 		return content;
 	}

--- a/backend/src/main/java/codesquard/app/issue/repository/IssueRepository.java
+++ b/backend/src/main/java/codesquard/app/issue/repository/IssueRepository.java
@@ -1,5 +1,6 @@
 package codesquard.app.issue.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import codesquard.app.issue.dto.response.IssueCommentsResponse;
@@ -25,11 +26,11 @@ public interface IssueRepository {
 
 	void saveIssueAssignee(Long issueId, List<Long> assignees);
 
-	void modifyStatus(String status, Long issueId);
+	void modifyStatus(String status, Long issueId, LocalDateTime now);
 
-	void modifyTitle(String toEntity, Long issueId);
+	void modifyTitle(String toEntity, Long issueId, LocalDateTime now);
 
-	void modifyContent(String content, Long issueId);
+	void modifyContent(String content, Long issueId, LocalDateTime now);
 
 	void modifyMilestone(Long milestoneId, Long issueId);
 

--- a/backend/src/main/java/codesquard/app/issue/repository/JdbcIssueRepository.java
+++ b/backend/src/main/java/codesquard/app/issue/repository/JdbcIssueRepository.java
@@ -1,5 +1,6 @@
 package codesquard.app.issue.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -137,21 +138,21 @@ public class JdbcIssueRepository implements IssueRepository {
 	}
 
 	@Override
-	public void modifyStatus(String status, Long issueId) {
-		String sql = "UPDATE issue SET status = :status WHERE id = :id";
-		template.update(sql, Map.of("status", status, "id", issueId));
+	public void modifyStatus(String status, Long issueId, LocalDateTime now) {
+		String sql = "UPDATE issue SET status = :status, status_modified_at = :now WHERE id = :id";
+		template.update(sql, Map.of("status", status, "id", issueId, "now", now));
 	}
 
 	@Override
-	public void modifyTitle(String title, Long issueId) {
-		String sql = "UPDATE issue SET title = :title WHERE id = :id";
-		template.update(sql, Map.of("title", title, "id", issueId));
+	public void modifyTitle(String title, Long issueId, LocalDateTime now) {
+		String sql = "UPDATE issue SET title = :title, modified_at = :now WHERE id = :id";
+		template.update(sql, Map.of("title", title, "id", issueId, "now", now));
 	}
 
 	@Override
-	public void modifyContent(String content, Long issueId) {
-		String sql = "UPDATE issue SET content = :content WHERE id = :id";
-		template.update(sql, Map.of("content", content, "id", issueId));
+	public void modifyContent(String content, Long issueId, LocalDateTime now) {
+		String sql = "UPDATE issue SET content = :content, modified_at = :now WHERE id = :id";
+		template.update(sql, Map.of("content", content, "id", issueId, "now", now));
 	}
 
 	@Override

--- a/backend/src/main/java/codesquard/app/issue/service/IssueService.java
+++ b/backend/src/main/java/codesquard/app/issue/service/IssueService.java
@@ -1,11 +1,10 @@
 package codesquard.app.issue.service;
 
+import java.time.LocalDateTime;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import codesquard.app.api.errors.errorcode.IssueErrorCode;
-import codesquard.app.api.errors.exception.IllegalIssueStatusException;
-import codesquard.app.api.errors.exception.NoSuchIssueException;
 import codesquard.app.comment.repository.CommentRepository;
 import codesquard.app.issue.dto.request.IssueModifyAssigneesRequest;
 import codesquard.app.issue.dto.request.IssueModifyContentRequest;
@@ -37,17 +36,17 @@ public class IssueService {
 	public void modifyStatus(IssueModifyStatusRequest issueModifyStatusRequest, Long issueId) {
 		IssueStatus issueStatus = IssueStatus.validateIssueStatus(issueModifyStatusRequest.getStatus());
 		issueQueryService.validateExistIssue(issueId);
-		issueRepository.modifyStatus(issueStatus.name(), issueId);
+		issueRepository.modifyStatus(issueStatus.name(), issueId, LocalDateTime.now());
 	}
 
 	public void modifyTitle(IssueModifyTitleRequest issueModifyTitleRequest, Long issueId) {
 		issueQueryService.validateExistIssue(issueId);
-		issueRepository.modifyTitle(issueModifyTitleRequest.getTitle(), issueId);
+		issueRepository.modifyTitle(issueModifyTitleRequest.getTitle(), issueId, LocalDateTime.now());
 	}
 
 	public void modifyContent(IssueModifyContentRequest issueModifyTitleRequest, Long issueId) {
 		issueQueryService.validateExistIssue(issueId);
-		issueRepository.modifyContent(issueModifyTitleRequest.getContent(), issueId);
+		issueRepository.modifyContent(issueModifyTitleRequest.getContent(), issueId, LocalDateTime.now());
 	}
 
 	public void modifyAssignees(IssueModifyAssigneesRequest issueModifyAssigneesRequest, Long issueId) {

--- a/backend/src/main/java/codesquard/app/user_reaction/controller/UserReactionController.java
+++ b/backend/src/main/java/codesquard/app/user_reaction/controller/UserReactionController.java
@@ -9,6 +9,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import codesquard.app.api.response.ApiResponse;
 import codesquard.app.api.response.ResponseMessage;
+import codesquard.app.authenticate_user.entity.AuthenticateUser;
+import codesquard.app.user.annotation.Login;
 import codesquard.app.user_reaction.dto.response.UserReactionSaveResponse;
 import codesquard.app.user_reaction.service.UserReactionService;
 import lombok.RequiredArgsConstructor;
@@ -23,8 +25,8 @@ public class UserReactionController {
 	@ResponseStatus(HttpStatus.CREATED)
 	@PostMapping("/{reactionId}/issues/{issueId}")
 	public ApiResponse<UserReactionSaveResponse> saveIssueReaction(@PathVariable Long reactionId,
-		@PathVariable Long issueId) {
-		Long userId = 1L;
+		@PathVariable Long issueId, @Login AuthenticateUser user) {
+		Long userId = user.toEntity().getId();
 		Long userReactionId = userReactionService.saveIssueReaction(reactionId, userId, issueId);
 		return ApiResponse.of(HttpStatus.CREATED, ResponseMessage.USER_REACTION_ISSUE_SAVE_SUCCESS,
 			UserReactionSaveResponse.success(userReactionId));
@@ -33,8 +35,8 @@ public class UserReactionController {
 	@ResponseStatus(HttpStatus.CREATED)
 	@PostMapping("/{reactionId}/comments/{commentId}")
 	public ApiResponse<UserReactionSaveResponse> saveCommentReaction(@PathVariable Long reactionId,
-		@PathVariable Long commentId) {
-		Long userId = 1L;
+		@PathVariable Long commentId, @Login AuthenticateUser user) {
+		Long userId = user.toEntity().getId();
 		Long userReactionId = userReactionService.saveCommentReaction(reactionId, userId, commentId);
 		return ApiResponse.of(HttpStatus.CREATED, ResponseMessage.USER_REACTION_COMMENT_SAVE_SUCCESS,
 			UserReactionSaveResponse.success(userReactionId));

--- a/backend/src/test/java/codesquard/app/issue/controller/IssueControllerTest.java
+++ b/backend/src/test/java/codesquard/app/issue/controller/IssueControllerTest.java
@@ -63,8 +63,7 @@ class IssueControllerTest extends ControllerTestSupport {
 	@Test
 	void create() throws Exception {
 		// given
-		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Controller", "내용", 1L,
-			anyLong());
+		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Controller", "내용", 1L, 1L);
 
 		// when & then
 		mockMvc.perform(post("/api/issues")
@@ -80,7 +79,7 @@ class IssueControllerTest extends ControllerTestSupport {
 	void create_InputZeroTitle_Response400() throws Exception {
 		// given
 		String zeroTitle = "";
-		IssueSaveRequest zero = FixtureFactory.createIssueRegisterRequest(zeroTitle, "내용", 1L, anyLong());
+		IssueSaveRequest zero = FixtureFactory.createIssueRegisterRequest(zeroTitle, "내용", 1L, 1L);
 
 		// when & then
 		mockMvc.perform(post("/api/issues")
@@ -96,7 +95,7 @@ class IssueControllerTest extends ControllerTestSupport {
 		// given
 		String title = generateExceedingMaxLengthContent(TITLE_MAX_LENGTH);
 
-		IssueSaveRequest over = FixtureFactory.createIssueRegisterRequest(title, "내용", 1L, anyLong());
+		IssueSaveRequest over = FixtureFactory.createIssueRegisterRequest(title, "내용", 1L, 1L);
 
 		// when & then
 		mockMvc.perform(post("/api/issues")
@@ -111,7 +110,7 @@ class IssueControllerTest extends ControllerTestSupport {
 	void create_InputBlankTitle_Response400() throws Exception {
 		// given
 		String blankTitle = " ";
-		IssueSaveRequest blank = FixtureFactory.createIssueRegisterRequest(blankTitle, "내용", 1L, anyLong());
+		IssueSaveRequest blank = FixtureFactory.createIssueRegisterRequest(blankTitle, "내용", 1L, 1L);
 
 		// when & then
 		mockMvc.perform(post("/api/issues")
@@ -127,7 +126,7 @@ class IssueControllerTest extends ControllerTestSupport {
 		// given
 		String content = generateExceedingMaxLengthContent(CONTENT_MAX_LENGTH);
 
-		IssueSaveRequest over = FixtureFactory.createIssueRegisterRequest("Controller", content, 1L, anyLong());
+		IssueSaveRequest over = FixtureFactory.createIssueRegisterRequest("Controller", content, 1L, 1L);
 
 		// when & then
 		mockMvc.perform(post("/api/issues")

--- a/backend/src/test/java/codesquard/app/issue/repository/JdbcIssueRepositoryTest.java
+++ b/backend/src/test/java/codesquard/app/issue/repository/JdbcIssueRepositoryTest.java
@@ -2,6 +2,8 @@ package codesquard.app.issue.repository;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.time.LocalDateTime;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -88,10 +90,12 @@ class JdbcIssueRepositoryTest extends IntegrationTestSupport {
 
 		// when
 		IssueStatus issueStatus = IssueStatus.CLOSED;
-		issueRepository.modifyStatus(issueStatus.name(), id);
+		LocalDateTime status_modified_at = LocalDateTime.now();
+		issueRepository.modifyStatus(issueStatus.name(), id, status_modified_at);
 
 		// then
 		assertThat(issueRepository.findBy(id).getStatus()).isEqualTo(issueStatus);
+		assertThat(issueRepository.findBy(id).getStatusModifiedAt()).isEqualTo(status_modified_at.withNano(0));
 	}
 
 	@DisplayName("이슈를 등록하고 그 등록 번호의 이슈 제목을 수정한다.")
@@ -102,10 +106,12 @@ class JdbcIssueRepositoryTest extends IntegrationTestSupport {
 
 		// when
 		String title = "Modified Repository Title";
-		issueRepository.modifyTitle(title, id);
+		LocalDateTime modified_at = LocalDateTime.now();
+		issueRepository.modifyTitle(title, id, modified_at);
 
 		// then
 		assertThat(issueRepository.findBy(id).getTitle()).isEqualTo(title);
+		assertThat(issueRepository.findBy(id).getModifiedAt()).isEqualTo(modified_at.withNano(0));
 	}
 
 	@DisplayName("이슈를 등록하고 그 등록 번호의 이슈 내용을 수정한다.")
@@ -116,10 +122,12 @@ class JdbcIssueRepositoryTest extends IntegrationTestSupport {
 
 		// when
 		String content = "Modified Repository Content";
-		issueRepository.modifyContent(content, id);
+		LocalDateTime modified_at = LocalDateTime.now();
+		issueRepository.modifyContent(content, id, modified_at);
 
 		// then
 		assertThat(issueRepository.findBy(id).getContent()).isEqualTo(content);
+		assertThat(issueRepository.findBy(id).getModifiedAt()).isEqualTo(modified_at.withNano(0));
 	}
 
 	@DisplayName("이슈를 등록하고 그 등록 번호의 마일스톤을 수정한다.")

--- a/backend/src/test/java/codesquard/app/user_reaction/repository/JdbcUserReactionRepositoryTest.java
+++ b/backend/src/test/java/codesquard/app/user_reaction/repository/JdbcUserReactionRepositoryTest.java
@@ -42,6 +42,9 @@ class JdbcUserReactionRepositoryTest extends IntegrationTestSupport {
 		jdbcTemplate.update("TRUNCATE TABLE user");
 		jdbcTemplate.update("TRUNCATE TABLE label");
 		jdbcTemplate.update("TRUNCATE TABLE user_reaction");
+		jdbcTemplate.update("TRUNCATE TABLE reaction");
+		jdbcTemplate.update(
+			"INSERT INTO reaction(unicode) VALUE('&#128077'), ('&#128078'), ('&#128522'), ('&#128569'), ('&#128149'), ('&#128035')");
 		jdbcTemplate.update("SET FOREIGN_KEY_CHECKS = 1");
 	}
 

--- a/backend/src/test/java/codesquard/app/user_reaction/service/UserReactionServiceTest.java
+++ b/backend/src/test/java/codesquard/app/user_reaction/service/UserReactionServiceTest.java
@@ -44,6 +44,9 @@ class UserReactionServiceTest extends IntegrationTestSupport {
 		jdbcTemplate.update("TRUNCATE TABLE user");
 		jdbcTemplate.update("TRUNCATE TABLE label");
 		jdbcTemplate.update("TRUNCATE TABLE user_reaction");
+		jdbcTemplate.update("TRUNCATE TABLE reaction");
+		jdbcTemplate.update(
+			"INSERT INTO reaction(unicode) VALUE('&#128077'), ('&#128078'), ('&#128522'), ('&#128569'), ('&#128149'), ('&#128035')");
 		jdbcTemplate.update("SET FOREIGN_KEY_CHECKS = 1");
 	}
 


### PR DESCRIPTION
## Description

- 이슈 상태 변경 시 status_modified_at 직접 데이터베이스에 추가
- 이슈 제목, 내용 변경 시 modified_at 직접 데이터베이스에 추가
-  Login 유저의 아이디를 가져오는 코드 추가

## Next Step

- 사용자 반응 삭제 API 구현
