### PR TITLE
[fe] 로그인/회원가입 구현

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,14 +1,20 @@
 import { useState } from "react";
-import { Route, BrowserRouter as Router, Routes } from "react-router-dom";
+import {
+  Navigate,
+  Route,
+  BrowserRouter as Router,
+  Routes,
+} from "react-router-dom";
 import { ThemeProvider, styled } from "styled-components";
 import { Header } from "./components/Header";
 import { designSystem } from "./constants/designSystem";
-import { Auth } from "./page/Auth";
 import { Error404 } from "./page/Error404";
+import { Auth } from "./page/auth/Auth";
 import { Label } from "./page/label/Label";
 import { Main } from "./page/main/Main";
 import { Milestone } from "./page/milestone/Milestone";
 import { NewIssue } from "./page/newIssue/NewIssue";
+import { getAccessToken } from "./utils/localStorage";
 
 export default function App() {
   const [themeMode, setThemeMode] = useState<"LIGHT" | "DARK">("LIGHT");
@@ -18,7 +24,7 @@ export default function App() {
       <Div>
         <Router>
           <Routes>
-            <Route path="/auth" element={<Auth />} />
+            <Route path="/auth" element={<AuthRoute />} />
             <Route path="*" element={<MainRoutes />} />
           </Routes>
         </Router>
@@ -29,7 +35,7 @@ export default function App() {
 
 function MainRoutes() {
   return (
-    <>
+    <PrivateRoute>
       <Header />
       <Routes>
         <Route path="/" element={<Main />} />
@@ -39,8 +45,20 @@ function MainRoutes() {
         <Route path="/milestone/:state" element={<Milestone />} />
         <Route path="*" element={<Error404 />} />
       </Routes>
-    </>
+    </PrivateRoute>
   );
+}
+
+function PrivateRoute({ children }: { children: React.ReactNode }) {
+  const accessToken = getAccessToken();
+
+  return accessToken ? children : <Navigate to="/auth" />;
+}
+
+function AuthRoute() {
+  const accessToken = getAccessToken();
+
+  return accessToken ? <Navigate to="/" /> : <Auth />;
 }
 
 const Div = styled.div`

--- a/frontend/src/assets/success.svg
+++ b/frontend/src/assets/success.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="170" height="170" viewBox="0 0 256 256" xml:space="preserve">
+
+<defs>
+</defs>
+<g style="stroke: none; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: none; fill-rule: nonzero; opacity: 1;" transform="translate(1.4065934065934016 1.4065934065934016) scale(2.81 2.81)" >
+	<circle cx="45" cy="45" r="45" style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: #007AFF; fill-rule: nonzero; opacity: 1;" transform="  matrix(1 0 0 1 0 0) "/>
+	<path d="M 38.478 64.5 c -0.01 0 -0.02 0 -0.029 0 c -1.3 -0.009 -2.533 -0.579 -3.381 -1.563 L 21.59 47.284 c -1.622 -1.883 -1.41 -4.725 0.474 -6.347 c 1.884 -1.621 4.725 -1.409 6.347 0.474 l 10.112 11.744 L 61.629 27.02 c 1.645 -1.862 4.489 -2.037 6.352 -0.391 c 1.862 1.646 2.037 4.49 0.391 6.352 l -26.521 30 C 40.995 63.947 39.767 64.5 38.478 64.5 z" style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-linejoin: miter; stroke-miterlimit: 10; fill: rgb(255,255,255); fill-rule: nonzero; opacity: 1;" transform=" matrix(1 0 0 1 0 0) " stroke-linecap="round" />
+</g>
+</svg>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,19 +1,31 @@
 import { useNavigate } from "react-router-dom";
 import { styled } from "styled-components";
+import { clearAuthInfo } from "../utils/localStorage";
+import { Button } from "./Button";
 import { Icon } from "./icon/Icon";
 
 export function Header() {
   const navigate = useNavigate();
+
+  const logOut = () => {
+    clearAuthInfo();
+    navigate("/auth");
+  };
 
   return (
     <Div>
       <Anchor onClick={() => navigate("/")}>
         <Icon name="LogoMedium" color="neutralTextStrong" />
       </Anchor>
-      <img
-        style={{ width: "32px" }}
-        src="https://avatars.githubusercontent.com/u/41321198?v=4"
-      />
+      <HeaderRight>
+        <img
+          style={{ width: "32px" }}
+          src="https://avatars.githubusercontent.com/u/41321198?v=4"
+        />
+        <Button size="S" buttonType="Ghost" onClick={logOut}>
+          로그아웃
+        </Button>
+      </HeaderRight>
     </Div>
   );
 }
@@ -28,4 +40,11 @@ const Div = styled.div`
 
 const Anchor = styled.a`
   cursor: pointer;
+`;
+
+const HeaderRight = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
 `;

--- a/frontend/src/components/icon/SvgIcons.tsx
+++ b/frontend/src/components/icon/SvgIcons.tsx
@@ -19,6 +19,7 @@ import { ReactComponent as Plus } from "../../assets/plus.svg";
 import { ReactComponent as RefreshCcw } from "../../assets/refreshCcw.svg";
 import { ReactComponent as Search } from "../../assets/search.svg";
 import { ReactComponent as Smile } from "../../assets/smile.svg";
+import { ReactComponent as success } from "../../assets/success.svg";
 import { ReactComponent as Trash } from "../../assets/trash.svg";
 import { ReactComponent as UserImageLarge } from "../../assets/userImageLarge.svg";
 import { ReactComponent as UserImageSmall } from "../../assets/userImageSmall.svg";
@@ -50,6 +51,7 @@ export const iconComponents = {
   UserImageLarge,
   UserImageSmall,
   XSquare,
+  success,
 };
 
 export const fillTypeComponents = [
@@ -58,5 +60,5 @@ export const fillTypeComponents = [
   UserImageSmall,
   Comment,
   LogoMedium,
-  LogoLarge
+  LogoLarge,
 ];

--- a/frontend/src/page/auth/SignUpSuccessModal.tsx
+++ b/frontend/src/page/auth/SignUpSuccessModal.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useRef } from "react";
+import { styled } from "styled-components";
+import { Button } from "../../components/Button";
+import { Icon } from "../../components/icon/Icon";
+
+export function SignUpSuccessModal({ onClick }: { onClick: () => void }) {
+  const modalRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    modalRef.current?.showModal();
+  }, []);
+
+  return (
+    <Dialog ref={modalRef}>
+      <Icon name="success" />
+      <Title>회원가입 되었습니다!</Title>
+      <span>로그인 버튼을 눌러서 로그인 화면으로 이동해 주세요.</span>
+      <Button size="M" buttonType="Container" onClick={onClick}>
+        로그인
+      </Button>
+    </Dialog>
+  );
+}
+
+const Dialog = styled.dialog`
+  width: 400px;
+  height: 700px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 40px;
+  border: none;
+`;
+
+const Title = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: ${({ theme }) => theme.color.neutralTextStrong};
+  font: ${({ theme }) => theme.font.displayBold32};
+`;

--- a/frontend/src/utils/localStorage.tsx
+++ b/frontend/src/utils/localStorage.tsx
@@ -1,0 +1,23 @@
+import { UserInfoData } from "../page/auth/Auth";
+
+export const setAccessToken = (accessToken: string) => {
+  localStorage.setItem("accessToken", accessToken);
+};
+
+export const setUserInfo = (userInfo: UserInfoData) => {
+  localStorage.setItem("userInfo", JSON.stringify(userInfo));
+};
+
+export const getAccessToken = () => {
+  return localStorage.getItem("accessToken");
+};
+
+export const getUserInfo = () => {
+  const userInfoJSON = localStorage.getItem("userInfo");
+
+  return userInfoJSON ? JSON.parse(userInfoJSON) : null;
+};
+export const clearAuthInfo = () => {
+  localStorage.removeItem("accessToken");
+  localStorage.removeItem("userInfo");
+};


### PR DESCRIPTION
## Description
- 로그인/회원가입 구현
- msw와 연동
- OAuth 미구현

## Key Changes
### 통신으로 받은 에러 메시지
![1](https://github.com/masters2023-3rd-project-bugbusters/issue-tracker-max/assets/41321198/9b708b84-7409-4563-909c-13ff6a72d7af)
  통신 후 받은 에러 메시지는 다음과 같이 표시합니다.
### 회원가입 성공
![2](https://github.com/masters2023-3rd-project-bugbusters/issue-tracker-max/assets/41321198/a1bcc6c3-33a1-45f5-ab5e-ee378c9142f1)
  성공하면 modal창이 나옵니다.
  
>  id : test123
  password : 12341234
  
기본적으로 msw에 저장 된 위 계정으로 로그인 가능합니다.
또는 회원가입으로 진행한 계정으로도 로그인 가능합니다.
### 로그아웃 버튼이 우측 상단 프로필 오른쪽에 추가 되었습니다.
![3](https://github.com/masters2023-3rd-project-bugbusters/issue-tracker-max/assets/41321198/b301c4e0-598f-45e7-b965-b84c04bf3ccb)

- accessToken은 localStorage에 저장 했습니다.
  - localStorage 선택 사유는 노션 Front Docs - 일지 - 8/9 에 있습니다.
- localStorage 관련 함수는 utils에 따로 보관 했습니다.
- 비 로그인 상태에서는 /auth 외 url 접근시 /auth로 리다이렉트 합니다.
- 로그인 상태에서는 /auth url 접근시 /로 리다이렉트 합니다.

## To Reviewers
생각 보다 작업 속도가 안 나오는 것 같아 조금 걱정입니다.
그래도 로그인 관련 상태는 구현되었습니다.
로그인 상태에서만 요청이 가능한 api 관련 설정이 필요한데 이 부분은 Oauth 로그인 까지 끝나면 추가 하겠습니다.

## Issue
- #158 

