### PR TITLE
[be] 사용자 반응 삭제 API 구현

### DIFF
--- a/backend/src/main/java/codesquard/app/api/errors/exception/NoSuchUserReactionException.java
+++ b/backend/src/main/java/codesquard/app/api/errors/exception/NoSuchUserReactionException.java
@@ -1,0 +1,10 @@
+package codesquard.app.api.errors.exception;
+
+public class NoSuchUserReactionException extends RuntimeException {
+
+	private static final String MESSAGE = "존재하지 않는 사용자 반응입니다.";
+
+	public NoSuchUserReactionException() {
+		super(MESSAGE);
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/errors/handler/UserReactionExceptionHandler.java
+++ b/backend/src/main/java/codesquard/app/api/errors/handler/UserReactionExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import codesquard.app.api.errors.exception.NoSuchReactionException;
+import codesquard.app.api.errors.exception.NoSuchUserReactionException;
 import codesquard.app.api.response.ApiResponse;
 
 @RestControllerAdvice
@@ -19,6 +20,17 @@ public class UserReactionExceptionHandler {
 	@ExceptionHandler(NoSuchReactionException.class)
 	public ApiResponse<Object> handleNoSuchReactionException(NoSuchReactionException e) {
 		logger.info("NoSuchReactionException handling : {}", e.toString());
+		return ApiResponse.of(
+			HttpStatus.NOT_FOUND,
+			e.getMessage(),
+			null
+		);
+	}
+
+	@ResponseStatus(HttpStatus.NOT_FOUND)
+	@ExceptionHandler(NoSuchUserReactionException.class)
+	public ApiResponse<Object> handleNoSuchUserReactionException(NoSuchUserReactionException e) {
+		logger.info("NoSuchUserReactionException handling : {}", e.toString());
 		return ApiResponse.of(
 			HttpStatus.NOT_FOUND,
 			e.getMessage(),

--- a/backend/src/main/java/codesquard/app/user_reaction/controller/UserReactionController.java
+++ b/backend/src/main/java/codesquard/app/user_reaction/controller/UserReactionController.java
@@ -1,6 +1,7 @@
 package codesquard.app.user_reaction.controller;
 
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import codesquard.app.api.response.ApiResponse;
 import codesquard.app.api.response.ResponseMessage;
+import codesquard.app.user_reaction.dto.response.UserReactionDeleteResponse;
 import codesquard.app.user_reaction.dto.response.UserReactionSaveResponse;
 import codesquard.app.user_reaction.service.UserReactionService;
 import lombok.RequiredArgsConstructor;
@@ -25,9 +27,9 @@ public class UserReactionController {
 	public ApiResponse<UserReactionSaveResponse> saveIssueReaction(@PathVariable Long reactionId,
 		@PathVariable Long issueId) {
 		Long userId = 1L;
-		Long userReactionId = userReactionService.saveIssueReaction(reactionId, userId, issueId);
+		Long id = userReactionService.saveIssueReaction(reactionId, userId, issueId);
 		return ApiResponse.of(HttpStatus.CREATED, ResponseMessage.USER_REACTION_ISSUE_SAVE_SUCCESS,
-			UserReactionSaveResponse.success(userReactionId));
+			UserReactionSaveResponse.success(id));
 	}
 
 	@ResponseStatus(HttpStatus.CREATED)
@@ -35,8 +37,14 @@ public class UserReactionController {
 	public ApiResponse<UserReactionSaveResponse> saveCommentReaction(@PathVariable Long reactionId,
 		@PathVariable Long commentId) {
 		Long userId = 1L;
-		Long userReactionId = userReactionService.saveCommentReaction(reactionId, userId, commentId);
+		Long id = userReactionService.saveCommentReaction(reactionId, userId, commentId);
 		return ApiResponse.of(HttpStatus.CREATED, ResponseMessage.USER_REACTION_COMMENT_SAVE_SUCCESS,
-			UserReactionSaveResponse.success(userReactionId));
+			UserReactionSaveResponse.success(id));
+	}
+
+	@DeleteMapping("/{userReactionId}")
+	public ApiResponse<UserReactionDeleteResponse> deleteIssueReaction(@PathVariable Long userReactionId) {
+		userReactionService.deleteIssueReaction(userReactionId);
+		return ApiResponse.ok(UserReactionDeleteResponse.success(userReactionId));
 	}
 }

--- a/backend/src/main/java/codesquard/app/user_reaction/dto/response/UserReactionDeleteResponse.java
+++ b/backend/src/main/java/codesquard/app/user_reaction/dto/response/UserReactionDeleteResponse.java
@@ -1,0 +1,16 @@
+package codesquard.app.user_reaction.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class UserReactionDeleteResponse {
+
+	@JsonProperty("deletedUserReactionId")
+	private final Long id;
+
+	public static UserReactionDeleteResponse success(Long userReactionId) {
+		return new UserReactionDeleteResponse(userReactionId);
+	}
+}

--- a/backend/src/main/java/codesquard/app/user_reaction/repository/JdbcUserReactionRepository.java
+++ b/backend/src/main/java/codesquard/app/user_reaction/repository/JdbcUserReactionRepository.java
@@ -36,9 +36,21 @@ public class JdbcUserReactionRepository implements UserReactionRepository {
 	}
 
 	@Override
-	public boolean isExist(Long reactionId) {
+	public void delete(Long id) {
+		String sql = "DELETE FROM user_reaction WHERE id = :id";
+		template.update(sql, Map.of("id", id));
+	}
+
+	@Override
+	public boolean isExistReaction(Long reactionId) {
 		String sql = "SELECT EXISTS (SELECT 1 FROM reaction WHERE id = :id)";
 		return Boolean.TRUE.equals(template.queryForObject(sql, Map.of("id", reactionId), Boolean.class));
+	}
+
+	@Override
+	public boolean isExistUserReaction(Long id) {
+		String sql = "SELECT EXISTS (SELECT 1 FROM user_reaction WHERE id = :id)";
+		return Boolean.TRUE.equals(template.queryForObject(sql, Map.of("id", id), Boolean.class));
 	}
 
 	private MapSqlParameterSource saveIssueParamSource(Long reactionId, Long userId, Long issueId) {

--- a/backend/src/main/java/codesquard/app/user_reaction/repository/UserReactionRepository.java
+++ b/backend/src/main/java/codesquard/app/user_reaction/repository/UserReactionRepository.java
@@ -5,5 +5,9 @@ public interface UserReactionRepository {
 
 	Long saveCommentReaction(Long reactionId, Long userId, Long commentId);
 
-	boolean isExist(Long reactionId);
+	void delete(Long id);
+
+	boolean isExistReaction(Long reactionId);
+
+	boolean isExistUserReaction(Long id);
 }

--- a/backend/src/main/java/codesquard/app/user_reaction/service/UserReactionQueryService.java
+++ b/backend/src/main/java/codesquard/app/user_reaction/service/UserReactionQueryService.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import codesquard.app.api.errors.exception.NoSuchReactionException;
+import codesquard.app.api.errors.exception.NoSuchUserReactionException;
 import codesquard.app.user_reaction.repository.UserReactionRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -15,8 +16,14 @@ public class UserReactionQueryService {
 	private final UserReactionRepository userReactionRepository;
 
 	public void validateExistReactionId(Long reactionId) {
-		if (!userReactionRepository.isExist(reactionId)) {
+		if (!userReactionRepository.isExistReaction(reactionId)) {
 			throw new NoSuchReactionException();
+		}
+	}
+
+	public void validateExistUserReactionId(Long userReactionId) {
+		if (!userReactionRepository.isExistUserReaction(userReactionId)) {
+			throw new NoSuchUserReactionException();
 		}
 	}
 }

--- a/backend/src/main/java/codesquard/app/user_reaction/service/UserReactionService.java
+++ b/backend/src/main/java/codesquard/app/user_reaction/service/UserReactionService.java
@@ -29,4 +29,9 @@ public class UserReactionService {
 		commentService.validateCommentId(commentId);
 		return userReactionRepository.saveCommentReaction(reactionId, userId, commentId);
 	}
+
+	public void deleteIssueReaction(Long id) {
+		userReactionQueryService.validateExistUserReactionId(id);
+		userReactionRepository.delete(id);
+	}
 }

--- a/backend/src/test/java/codesquard/app/user_reaction/controller/UserReactionControllerTest.java
+++ b/backend/src/test/java/codesquard/app/user_reaction/controller/UserReactionControllerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 import codesquard.app.ControllerTestSupport;
 import codesquard.app.api.errors.exception.NoSuchReactionException;
+import codesquard.app.api.errors.exception.NoSuchUserReactionException;
 
 class UserReactionControllerTest extends ControllerTestSupport {
 
@@ -68,6 +69,33 @@ class UserReactionControllerTest extends ControllerTestSupport {
 
 		// when & then
 		mockMvc.perform(post("/api/reactions/" + reactionId + "/comments/" + commentId))
+			.andExpect(status().isNotFound())
+			.andDo(print());
+	}
+
+	@DisplayName("사용자 반응을 삭제한다.")
+	@Test
+	void deleteUserReaction() throws Exception {
+		// given
+		int userReactionId = 1;
+
+		// when & then
+		mockMvc.perform(delete("/api/reactions/" + userReactionId))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.deletedUserReactionId").value(userReactionId))
+			.andDo(print());
+	}
+
+	@DisplayName("사용자 반응이 존재하지 않을 때 사용자 반응 삭제에 실패한다.")
+	@Test
+	void deleteUserReaction_Fail() throws Exception {
+		// given
+		Long userReactionId = 1L;
+		willThrow(new NoSuchUserReactionException())
+			.given(userReactionService).deleteIssueReaction(userReactionId);
+
+		// when & then
+		mockMvc.perform(delete("/api/reactions/" + userReactionId))
 			.andExpect(status().isNotFound())
 			.andDo(print());
 	}

--- a/backend/src/test/java/codesquard/app/user_reaction/repository/JdbcUserReactionRepositoryTest.java
+++ b/backend/src/test/java/codesquard/app/user_reaction/repository/JdbcUserReactionRepositoryTest.java
@@ -40,6 +40,7 @@ class JdbcUserReactionRepositoryTest extends IntegrationTestSupport {
 		jdbcTemplate.update("TRUNCATE TABLE issue");
 		jdbcTemplate.update("TRUNCATE TABLE milestone");
 		jdbcTemplate.update("TRUNCATE TABLE user");
+		jdbcTemplate.update("TRUNCATE TABLE comment");
 		jdbcTemplate.update("TRUNCATE TABLE label");
 		jdbcTemplate.update("TRUNCATE TABLE user_reaction");
 		jdbcTemplate.update("SET FOREIGN_KEY_CHECKS = 1");
@@ -84,5 +85,26 @@ class JdbcUserReactionRepositoryTest extends IntegrationTestSupport {
 
 		// then
 		assertThat(id).isNotNull();
+	}
+
+	@DisplayName("이슈 사용자 반응을 등록하고 그 등록 번호를 삭제한다.")
+	@Test
+	void delete() {
+		// given
+		Long loginId = userRepository.save(FixtureFactory.createUserSaveServiceRequest().toEntity());
+		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Repository", "내용", null,
+			loginId);
+		Issue issue = issueSaveRequest.toEntity(loginId);
+		Long issueId = issueRepository.save(issue);
+		issueRepository.saveIssueLabel(issueId, issueSaveRequest.getLabels());
+		issueRepository.saveIssueAssignee(issueId, issueSaveRequest.getAssignees());
+		Long reactionId = 1L;
+		Long id = userReactionRepository.saveIssueReaction(reactionId, loginId, issueId);
+
+		// when
+		userReactionRepository.delete(id);
+
+		// then
+		assertThat(userReactionRepository.isExistUserReaction(id)).isFalse();
 	}
 }

--- a/backend/src/test/java/codesquard/app/user_reaction/service/UserReactionServiceTest.java
+++ b/backend/src/test/java/codesquard/app/user_reaction/service/UserReactionServiceTest.java
@@ -14,6 +14,7 @@ import codesquard.app.IntegrationTestSupport;
 import codesquard.app.api.errors.exception.NoSuchCommentException;
 import codesquard.app.api.errors.exception.NoSuchIssueException;
 import codesquard.app.api.errors.exception.NoSuchReactionException;
+import codesquard.app.api.errors.exception.NoSuchUserReactionException;
 import codesquard.app.comment.service.CommentService;
 import codesquard.app.comment.service.request.CommentSaveServiceRequest;
 import codesquard.app.issue.dto.request.IssueSaveRequest;
@@ -25,6 +26,8 @@ class UserReactionServiceTest extends IntegrationTestSupport {
 
 	@Autowired
 	private UserReactionService userReactionService;
+	@Autowired
+	private UserReactionQueryService userReactionQueryService;
 	@Autowired
 	private UserRepository userRepository;
 	@Autowired
@@ -42,6 +45,7 @@ class UserReactionServiceTest extends IntegrationTestSupport {
 		jdbcTemplate.update("TRUNCATE TABLE issue");
 		jdbcTemplate.update("TRUNCATE TABLE milestone");
 		jdbcTemplate.update("TRUNCATE TABLE user");
+		jdbcTemplate.update("TRUNCATE TABLE comment");
 		jdbcTemplate.update("TRUNCATE TABLE label");
 		jdbcTemplate.update("TRUNCATE TABLE user_reaction");
 		jdbcTemplate.update("SET FOREIGN_KEY_CHECKS = 1");
@@ -135,5 +139,34 @@ class UserReactionServiceTest extends IntegrationTestSupport {
 		// when & then
 		assertThatThrownBy(() -> userReactionService.saveCommentReaction(reactionId, loginId, commentId)).isInstanceOf(
 			NoSuchCommentException.class);
+	}
+
+	@DisplayName("사용자 반응을 삭제한다.")
+	@Test
+	void delete() {
+		// given
+		Long loginId = userRepository.save(FixtureFactory.createUserSaveServiceRequest().toEntity());
+		IssueSaveRequest issueSaveRequest = FixtureFactory.createIssueRegisterRequest("Service", "내용", null, loginId);
+		Long issueId = issueService.save(issueSaveRequest, loginId);
+		Long reactionId = 1L;
+		Long id = userReactionService.saveIssueReaction(reactionId, loginId, issueId);
+
+		// when
+		userReactionService.deleteIssueReaction(id);
+
+		// then
+		assertThatThrownBy(() -> userReactionQueryService.validateExistUserReactionId(id)).isInstanceOf(
+			NoSuchUserReactionException.class);
+	}
+
+	@DisplayName("사용자 반응 삭제에 실패한다.")
+	@Test
+	void delete_Fail() {
+		// given
+		Long id = 10000L;
+		
+		// when & then
+		assertThatThrownBy(() -> userReactionService.deleteIssueReaction(id)).isInstanceOf(
+			NoSuchUserReactionException.class);
 	}
 }


### PR DESCRIPTION
## Description

- 사용자 반응 삭제
- 테스트 코드 작성
- 예외 처리
  - 사용자 반응 아이디가 존재하지 않을 경우

## Next Step

-이슈 상세 조회 API에 사용자 반응 조회 추가