### PR TITLE
[fe] Avatar 컴포넌트 구현

### DIFF
--- a/frontend/src/components/Avatar.tsx
+++ b/frontend/src/components/Avatar.tsx
@@ -1,0 +1,60 @@
+import { styled } from "styled-components";
+
+type AvatarSize = "S" | "L";
+
+type AvatarProps = {
+  src?: string;
+  userId?: string;
+  size: AvatarSize;
+};
+
+export function Avatar({ src, userId, size }: AvatarProps) {
+  const generateColor = (userId: string) => {
+    let hash = 0;
+    for (let i = 0; i < userId.length; i++) {
+      hash = userId.charCodeAt(i) + ((hash << 5) - hash);
+    }
+    let color = "#";
+    for (let i = 0; i < 3; i++) {
+      const value = (hash >> (i * 8)) & 0xff;
+      color += ("00" + value.toString(16)).substr(-2);
+    }
+    return color;
+  };
+
+  return (
+    <Div $size={size}>
+      {src ? (
+        <img src={src} />
+      ) : (
+        <BaseAvatar fill={userId ? generateColor(userId) : "#DDD"} />
+      )}
+    </Div>
+  );
+}
+
+function BaseAvatar({ fill }: { fill: string }) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 340 340">
+      <path
+        fill={fill}
+        d="m169,.5a169,169 0 1,0 2,0zm0,86a76,76 0 1 1-2,0zM57,287q27-35 67-35h92q40,0 67,35a164,164 0 0,1-226,0"
+      />
+    </svg>
+  );
+}
+
+const Div = styled.div<{ $size: AvatarSize }>`
+  width: ${({ $size }) => ($size === "L" ? "32px" : "20px")};
+  height: ${({ $size }) => ($size === "L" ? "32px" : "20px")};
+  background: ${({ theme }) => theme.color.neutralSurfaceDefault};
+  border: 1px solid ${({ theme }) => theme.color.neutralSurfaceDefault};
+  border-radius: 32px;
+
+  & img,
+  svg {
+    width: 100%;
+    height: 100%;
+    border-radius: 32px;
+  }
+`;

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from "react-router-dom";
 import { styled } from "styled-components";
 import { clearAuthInfo } from "../utils/localStorage";
+import { Avatar } from "./Avatar";
 import { Button } from "./Button";
 import { Icon } from "./icon/Icon";
 
@@ -18,8 +19,8 @@ export function Header() {
         <Icon name="LogoMedium" color="neutralTextStrong" />
       </Anchor>
       <HeaderRight>
-        <img
-          style={{ width: "32px" }}
+        <Avatar
+          size="L"
           src="https://avatars.githubusercontent.com/u/41321198?v=4"
         />
         <Button size="S" buttonType="Ghost" onClick={logOut}>

--- a/frontend/src/components/issue/Issue.tsx
+++ b/frontend/src/components/issue/Issue.tsx
@@ -1,6 +1,7 @@
 import { styled } from "styled-components";
 import { IssueData } from "../../page/main/Main";
 import { getElapsedSince } from "../../utils/getElapsedSince";
+import { Avatar } from "../Avatar";
 import { InformationTag } from "../InformationTag";
 import { Icon, ThemeColorKeys } from "../icon/Icon";
 
@@ -49,8 +50,8 @@ export function Issue({ issue }: { issue: IssueData }) {
         </IssueInfo>
       </IssueContent>
       <AssigneesDiv>
-        <img
-          style={{ width: "20px" }}
+        <Avatar
+          size="S"
           src="https://avatars.githubusercontent.com/u/41321198?v=4"
         />
       </AssigneesDiv>

--- a/frontend/src/page/newIssue/NewIssueBody.tsx
+++ b/frontend/src/page/newIssue/NewIssueBody.tsx
@@ -1,4 +1,5 @@
 import { styled } from "styled-components";
+import { Avatar } from "../../components/Avatar";
 import { TextArea } from "../../components/TextArea";
 import { TextInput } from "../../components/TextInput";
 import { Sidebar, SidebarProps } from "../../components/sidebar/Sidebar";
@@ -27,8 +28,8 @@ export function NewIssueBody({
 
   return (
     <Div>
-      <img
-        style={{ width: "32px" }}
+      <Avatar
+        size="L"
         src="https://avatars.githubusercontent.com/u/41321198?v=4"
       />
       <NewIssueContent>


### PR DESCRIPTION
## Description
공용으로 사용할 Avatar 컴포넌트 구현 했습니다.

## Key Changes
```ts
type AvatarProps = {
  src?: string;
  userId?: string;
  size: AvatarSize;
};
```
Avatar 컴포넌트는 위 3가지 props를 받을 수 있습니다.
- src를 입력하면 해당 url의 이미지로 설정됩니다.
- src를 입력하지 않을 경우 기본 프로필이 설정됩니다.
- src와 userId를 함께 입력하면 userId를 해시 값으로 계산하고 그 값을 RGB로 변환하여 id에 매칭되는 색상을 넣습니다.
  - 같은 id에는 항상 같은 색상이 나옵니다.
  - userId를 넣는건 사용처의 선택이며 저희 코드에서 avatar가 없는 유저를 색상을 넣을지 안 넣을지 정하면 될 것 같습니다.
- size는 S과 L만 있으며 S는 20px L은 32px입니다.


```ts
  <Avatar
    size="L"
    src="https://avatars.githubusercontent.com/u/41321198?v=4"
  />
  <Avatar size="L" />
  <Avatar size="L" userId="altmit" />
```
![1](https://github.com/masters2023-3rd-project-bugbusters/issue-tracker-max/assets/41321198/fbd291ca-a82a-4171-b8c4-a9ebd2bc1e8b)



## Issue
- #161 
