### PR TITLE
[fe] 요청이 5173포트로 보내지는 문제

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,6 +6,13 @@ import svgr from "vite-plugin-svgr";
 export default defineConfig({
   plugins: [react(), svgr()],
   server: {
+    proxy: {
+      "/api": {
+        target: "http://3.36.120.124:8080",
+        changeOrigin: true,
+        secure: false,
+      }
+    },
     watch: {
       usePolling: true, // 폴링은 주기적으로 파일 시스템을 체크하여 변경 사항을 감지하는 방식
     },


### PR DESCRIPTION
## Description

배포 환경에서 요청이 5173 포트로 보내지는 문제가 발생해 웹 페이지가 정상적으로 동작하지 않습니다.
![image (1)](https://github.com/masters2023-3rd-project-bugbusters/issue-tracker-max/assets/60080167/02292ee7-7620-4da6-a8e5-2a8a9ed73aca)

저희 코드에서 아래처럼 요청을 보내면 same origin 의 8080 포트로 요청이 갈 것이라 기대했는데, 그렇게 처리되지 않는 것 같아 Vite에서 제공하는 proxy 설정을 해줬습니다.

**요청 코드 예시**
```
const res = await fetch("/api/users", {
      method: "POST",
      headers: {
        "Content-Type": "application/json",
      },
      body: JSON.stringify({
        loginId: loginId,
        email: email,
        password: password,
        passwordConfirm: passwordConfirm,
      }),
    });
```

**Vite proxy 설정**
```
server: {
    proxy: {
      "/api": {
        target: "http://3.36.120.124:8080",
        changeOrigin: true,
        secure: false,
      }
    },
    ...
  },
```

## Issues

- #178 

## Next Step

다음 진행 사항
