### PR TITLE
[be] vite 설정 오타 수정 및 배포환경에서 EC2MetadataUtils 문제 해결

### DIFF
--- a/backend/src/main/java/codesquard/BackendApplication.java
+++ b/backend/src/main/java/codesquard/BackendApplication.java
@@ -6,6 +6,10 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class BackendApplication {
 
+	static {
+		System.setProperty("com.amazonaws.sdk.disableEc2Metadata", "true");
+	}
+
 	public static void main(String[] args) {
 		SpringApplication.run(BackendApplication.class, args);
 	}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,17 +4,19 @@ import svgr from "vite-plugin-svgr";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react(), svgr()],
-  server: {
-    proxy: {
-      "/api": {
-        target: "http://3.36.120.124:8080",
-        changeOrigin: true,
-        secure: false,
-      }
+    plugins: [react(), svgr()],
+    server: {
+        proxy: {
+            "/api": {
+                target: "http://3.36.120.124:8080",
+                changeOrigin: true,
+                secure: false,
+            }
+        },
+        watch: {
+            usePolling: true, // 폴링은 주기적으로 파일 시스템을 체크하여 변경 사항을 감지하는 방식
+        },
+        host: true, // needed for the Docker Container port mapping to work
+        port: 5173, // you can replace this port with any port
     },
-    watch: {
-      usePolling: true, // 폴링은 주기적으로 파일 시스템을 체크하여 변경 사항을 감지하는 방식
-    },
-  }
 });


### PR DESCRIPTION
## Description

- com.amazonaws.util.EC2MetadataUtils 예외 발생 문제를 해결하였습니다. 해당 원인은 EC2 인스턴스(S3가 존재하는 계정의 EC2 인스턴스)가 아닌 곳에서 요청을 했기 때문으로 보입니다. 따라서 비활성화 설정하였습니다.
- vite 설정 파일에서 host와 port를 지정하지 않아 도커 컨테이너에 매핑되지 않은 문제를 해결하였습니다.

## Next Step

- 로그아웃 기능 구현
- 패스워드 암호화