### PR TITLE
[be] MultiFilter Response 구조 변경 및 데이터 추가

### DIFF
--- a/backend/src/main/java/codesquard/app/issue/mapper/IssueMapper.java
+++ b/backend/src/main/java/codesquard/app/issue/mapper/IssueMapper.java
@@ -7,26 +7,26 @@ import org.apache.ibatis.annotations.Param;
 
 import codesquard.app.issue.mapper.request.IssueFilterRequest;
 import codesquard.app.issue.mapper.response.IssuesResponse;
-import codesquard.app.issue.mapper.response.filters.response.MultiFiltersAssignees;
-import codesquard.app.issue.mapper.response.filters.response.MultiFiltersAuthors;
-import codesquard.app.issue.mapper.response.filters.response.MultiFiltersLabels;
-import codesquard.app.issue.mapper.response.filters.response.MultiFiltersMilestones;
+import codesquard.app.issue.mapper.response.filters.response.MultiFilterAssignee;
+import codesquard.app.issue.mapper.response.filters.response.MultiFilterAuthor;
+import codesquard.app.issue.mapper.response.filters.response.MultiFilterLabel;
+import codesquard.app.issue.mapper.response.filters.response.MultiFilterMilestone;
 
 @Mapper
 public interface IssueMapper {
 
 	List<IssuesResponse> getIssues(IssueFilterRequest request);
 
-	List<MultiFiltersAssignees> getMultiFiltersAssignees(@Param("check") boolean check,
+	List<MultiFilterAssignee> getMultiFiltersAssignees(@Param("check") boolean check,
 		@Param("request") IssueFilterRequest request);
 
-	List<MultiFiltersAuthors> getMultiFiltersAuthors(@Param("check") boolean check,
+	List<MultiFilterAuthor> getMultiFiltersAuthors(@Param("check") boolean check,
 		@Param("request") IssueFilterRequest request);
 
-	List<MultiFiltersLabels> getMultiFiltersLabels(@Param("check") boolean check,
+	List<MultiFilterLabel> getMultiFiltersLabels(@Param("check") boolean check,
 		@Param("request") IssueFilterRequest request);
 
-	List<MultiFiltersMilestones> getMultiFiltersMilestones(@Param("check") boolean check,
+	List<MultiFilterMilestone> getMultiFiltersMilestones(@Param("check") boolean check,
 		@Param("request") IssueFilterRequest request);
 
 }

--- a/backend/src/main/java/codesquard/app/issue/mapper/response/filters/MultiFilters.java
+++ b/backend/src/main/java/codesquard/app/issue/mapper/response/filters/MultiFilters.java
@@ -1,11 +1,9 @@
 package codesquard.app.issue.mapper.response.filters;
 
-import java.util.List;
-
-import codesquard.app.issue.mapper.response.filters.response.MultiFiltersAssignees;
-import codesquard.app.issue.mapper.response.filters.response.MultiFiltersAuthors;
-import codesquard.app.issue.mapper.response.filters.response.MultiFiltersLabels;
-import codesquard.app.issue.mapper.response.filters.response.MultiFiltersMilestones;
+import codesquard.app.issue.mapper.response.filters.response.MultiFilterAssignees;
+import codesquard.app.issue.mapper.response.filters.response.MultiFilterAuthors;
+import codesquard.app.issue.mapper.response.filters.response.MultiFilterLabels;
+import codesquard.app.issue.mapper.response.filters.response.MultiFilterMilestones;
 import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 
@@ -13,39 +11,27 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MultiFilters {
 
-	private List<MultiFiltersAssignees> assignees;
+	private MultiFilterAssignees assignees;
 
-	private List<MultiFiltersLabels> labels;
+	private MultiFilterLabels labels;
 
-	private List<MultiFiltersMilestones> milestones;
+	private MultiFilterMilestones milestones;
 
-	private List<MultiFiltersAuthors> authors;
+	private MultiFilterAuthors authors;
 
-	public void addNoneOptionToAssignee(boolean selected) {
-		assignees.add(new MultiFiltersAssignees(0L, "담당자가 없는 이슈", null, selected));
-	}
-
-	public void addNoneOptionToLabels(boolean selected) {
-		labels.add(new MultiFiltersLabels(0L, "라벨이 없는 이슈", null, null, selected));
-	}
-
-	public void addNoneOptionToMilestones(boolean selected) {
-		milestones.add(new MultiFiltersMilestones(0L, "마일스톤이 없는 이슈", selected));
-	}
-
-	public List<MultiFiltersAssignees> getAssignees() {
+	public MultiFilterAssignees getAssignees() {
 		return assignees;
 	}
 
-	public List<MultiFiltersLabels> getLabels() {
+	public MultiFilterLabels getLabels() {
 		return labels;
 	}
 
-	public List<MultiFiltersMilestones> getMilestones() {
+	public MultiFilterMilestones getMilestones() {
 		return milestones;
 	}
 
-	public List<MultiFiltersAuthors> getAuthors() {
+	public MultiFilterAuthors getAuthors() {
 		return authors;
 	}
 

--- a/backend/src/main/java/codesquard/app/issue/mapper/response/filters/response/MultiFilterAssignee.java
+++ b/backend/src/main/java/codesquard/app/issue/mapper/response/filters/response/MultiFilterAssignee.java
@@ -5,7 +5,7 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 @AllArgsConstructor
-public class MultiFiltersAuthors {
+public class MultiFilterAssignee {
 
 	private Long id;
 	private String name;
@@ -24,7 +24,7 @@ public class MultiFiltersAuthors {
 		return avatarUrl;
 	}
 
-	public boolean getSelected() {
+	public boolean isSelected() {
 		return selected;
 	}
 

--- a/backend/src/main/java/codesquard/app/issue/mapper/response/filters/response/MultiFilterAssignees.java
+++ b/backend/src/main/java/codesquard/app/issue/mapper/response/filters/response/MultiFilterAssignees.java
@@ -1,0 +1,30 @@
+package codesquard.app.issue.mapper.response.filters.response;
+
+import java.util.List;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class MultiFilterAssignees {
+
+	private boolean multipleSelect = false;
+
+	private List<MultiFilterAssignee> options;
+
+	public MultiFilterAssignees(List<MultiFilterAssignee> options) {
+		this.options = options;
+	}
+
+	public void addNoneOptionToAssignee(boolean selected) {
+		options.add(new MultiFilterAssignee(0L, "담당자가 없는 이슈", null, selected));
+	}
+
+	public boolean isMultipleSelect() {
+		return multipleSelect;
+	}
+
+	public List<MultiFilterAssignee> getOptions() {
+		return options;
+	}
+
+}

--- a/backend/src/main/java/codesquard/app/issue/mapper/response/filters/response/MultiFilterAuthor.java
+++ b/backend/src/main/java/codesquard/app/issue/mapper/response/filters/response/MultiFilterAuthor.java
@@ -5,10 +5,11 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 @AllArgsConstructor
-public class MultiFiltersMilestones {
+public class MultiFilterAuthor {
 
 	private Long id;
 	private String name;
+	private String avatarUrl;
 	private boolean selected;
 
 	public Long getId() {
@@ -19,7 +20,11 @@ public class MultiFiltersMilestones {
 		return name;
 	}
 
-	public boolean isSelected() {
+	public String getAvatarUrl() {
+		return avatarUrl;
+	}
+
+	public boolean getSelected() {
 		return selected;
 	}
 

--- a/backend/src/main/java/codesquard/app/issue/mapper/response/filters/response/MultiFilterAuthors.java
+++ b/backend/src/main/java/codesquard/app/issue/mapper/response/filters/response/MultiFilterAuthors.java
@@ -1,0 +1,26 @@
+package codesquard.app.issue.mapper.response.filters.response;
+
+import java.util.List;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class MultiFilterAuthors {
+
+	private boolean multipleSelect = false;
+
+	private List<MultiFilterAuthor> options;
+
+	public MultiFilterAuthors(List<MultiFilterAuthor> options) {
+		this.options = options;
+	}
+
+	public boolean isMultipleSelect() {
+		return multipleSelect;
+	}
+
+	public List<MultiFilterAuthor> getOptions() {
+		return options;
+	}
+
+}

--- a/backend/src/main/java/codesquard/app/issue/mapper/response/filters/response/MultiFilterLabel.java
+++ b/backend/src/main/java/codesquard/app/issue/mapper/response/filters/response/MultiFilterLabel.java
@@ -5,7 +5,7 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 @AllArgsConstructor
-public class MultiFiltersLabels {
+public class MultiFilterLabel {
 
 	private Long id;
 	private String name;

--- a/backend/src/main/java/codesquard/app/issue/mapper/response/filters/response/MultiFilterLabels.java
+++ b/backend/src/main/java/codesquard/app/issue/mapper/response/filters/response/MultiFilterLabels.java
@@ -1,0 +1,30 @@
+package codesquard.app.issue.mapper.response.filters.response;
+
+import java.util.List;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class MultiFilterLabels {
+
+	private boolean multipleSelect = true;
+
+	private List<MultiFilterLabel> options;
+
+	public MultiFilterLabels(List<MultiFilterLabel> options) {
+		this.options = options;
+	}
+
+	public void addNoneOptionToLabels(boolean selected) {
+		options.add(new MultiFilterLabel(0L, "라벨이 없는 이슈", null, null, selected));
+	}
+
+	public boolean isMultipleSelect() {
+		return multipleSelect;
+	}
+
+	public List<MultiFilterLabel> getOptions() {
+		return options;
+	}
+
+}

--- a/backend/src/main/java/codesquard/app/issue/mapper/response/filters/response/MultiFilterMilestone.java
+++ b/backend/src/main/java/codesquard/app/issue/mapper/response/filters/response/MultiFilterMilestone.java
@@ -5,11 +5,10 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 @AllArgsConstructor
-public class MultiFiltersAssignees {
+public class MultiFilterMilestone {
 
 	private Long id;
 	private String name;
-	private String avatarUrl;
 	private boolean selected;
 
 	public Long getId() {
@@ -18,10 +17,6 @@ public class MultiFiltersAssignees {
 
 	public String getName() {
 		return name;
-	}
-
-	public String getAvatarUrl() {
-		return avatarUrl;
 	}
 
 	public boolean isSelected() {

--- a/backend/src/main/java/codesquard/app/issue/mapper/response/filters/response/MultiFilterMilestones.java
+++ b/backend/src/main/java/codesquard/app/issue/mapper/response/filters/response/MultiFilterMilestones.java
@@ -1,0 +1,30 @@
+package codesquard.app.issue.mapper.response.filters.response;
+
+import java.util.List;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class MultiFilterMilestones {
+
+	private boolean multipleSelect = false;
+
+	private List<MultiFilterMilestone> options;
+
+	public MultiFilterMilestones(List<MultiFilterMilestone> options) {
+		this.options = options;
+	}
+
+	public void addNoneOptionToMilestones(boolean selected) {
+		options.add(new MultiFilterMilestone(0L, "마일스톤이 없는 이슈", selected));
+	}
+
+	public boolean isMultipleSelect() {
+		return multipleSelect;
+	}
+
+	public List<MultiFilterMilestone> getOptions() {
+		return options;
+	}
+
+}

--- a/backend/src/main/java/codesquard/app/issue/service/IssueQueryService.java
+++ b/backend/src/main/java/codesquard/app/issue/service/IssueQueryService.java
@@ -21,6 +21,10 @@ import codesquard.app.issue.mapper.request.IssueFilterRequest;
 import codesquard.app.issue.mapper.response.IssueFilterResponse;
 import codesquard.app.issue.mapper.response.IssuesResponse;
 import codesquard.app.issue.mapper.response.filters.MultiFilters;
+import codesquard.app.issue.mapper.response.filters.response.MultiFilterAssignees;
+import codesquard.app.issue.mapper.response.filters.response.MultiFilterAuthors;
+import codesquard.app.issue.mapper.response.filters.response.MultiFilterLabels;
+import codesquard.app.issue.mapper.response.filters.response.MultiFilterMilestones;
 import codesquard.app.issue.mapper.response.filters.response.SingleFilter;
 import codesquard.app.issue.repository.IssueRepository;
 import codesquard.app.label.repository.LabelRepository;
@@ -171,13 +175,16 @@ public class IssueQueryService {
 
 	private MultiFilters checkMultiFilters(boolean check, IssueFilterRequest request) {
 		MultiFilters multiFilters = new MultiFilters(
-			issueMapper.getMultiFiltersAssignees(check, request),
-			issueMapper.getMultiFiltersLabels(check, request),
-			issueMapper.getMultiFiltersMilestones(check, request),
-			issueMapper.getMultiFiltersAuthors(check, request));
-		multiFilters.addNoneOptionToAssignee(request.getAssignee() != null && request.getAssignee().equals("none"));
-		multiFilters.addNoneOptionToLabels(request.getLabel() != null && request.getLabel().get(0).equals("none"));
-		multiFilters.addNoneOptionToMilestones(request.getMilestone() != null && request.getMilestone().equals("none"));
+			new MultiFilterAssignees(issueMapper.getMultiFiltersAssignees(check, request)),
+			new MultiFilterLabels(issueMapper.getMultiFiltersLabels(check, request)),
+			new MultiFilterMilestones(issueMapper.getMultiFiltersMilestones(check, request)),
+			new MultiFilterAuthors(issueMapper.getMultiFiltersAuthors(check, request)));
+		multiFilters.getAssignees()
+			.addNoneOptionToAssignee(request.getAssignee() != null && request.getAssignee().equals("none"));
+		multiFilters.getLabels()
+			.addNoneOptionToLabels(request.getLabel() != null && request.getLabel().get(0).equals("none"));
+		multiFilters.getMilestones()
+			.addNoneOptionToMilestones(request.getMilestone() != null && request.getMilestone().equals("none"));
 		return multiFilters;
 	}
 

--- a/backend/src/main/java/codesquard/app/issue/service/IssueQueryService.java
+++ b/backend/src/main/java/codesquard/app/issue/service/IssueQueryService.java
@@ -119,7 +119,7 @@ public class IssueQueryService {
 		}
 
 		if (builder.length() == 0) {
-			return "";
+			return "is:opened";
 		}
 
 		return builder.toString();

--- a/backend/src/main/resources/codesquard/app/issue/mapper/IssueMapper.xml
+++ b/backend/src/main/resources/codesquard/app/issue/mapper/IssueMapper.xml
@@ -117,6 +117,7 @@
                 </otherwise>
             </choose>
         </where>
+        ORDER BY issue.`created_at` DESC
     </select>
 
     <resultMap id="issueAssigneeResponse" type="codesquard.app.issue.mapper.response.IssueAssigneeResponse">

--- a/backend/src/main/resources/codesquard/app/issue/mapper/IssueMapper.xml
+++ b/backend/src/main/resources/codesquard/app/issue/mapper/IssueMapper.xml
@@ -43,7 +43,7 @@
         <where>
             issue.`is_deleted` = 0
             <choose>
-                <when test="is == null and milestone == null and author == null and assignee == null label == null">
+                <when test="is == null and milestone == null and author == null and assignee == null and label == null and mentions == null">
                     AND issue.`status` = "OPENED"
                 </when>
                 <otherwise>
@@ -105,6 +105,14 @@
                                 HAVING COUNT(issue_label.`issue_id`) >= ${label.size})
                             </otherwise>
                         </choose>
+                    </if>
+                    <if test="mentions != null">
+                        AND issue.`id` IN (
+                        SELECT DISTINCT(comment.`issue_id`)
+                        FROM comment AS comment
+                        LEFT OUTER JOIN user AS u
+                        ON u.`id` = comment.`user_id`
+                        WHERE u.`login_id` = #{mentions})
                     </if>
                 </otherwise>
             </choose>

--- a/backend/src/main/resources/codesquard/app/issue/mapper/IssueMapper.xml
+++ b/backend/src/main/resources/codesquard/app/issue/mapper/IssueMapper.xml
@@ -150,7 +150,7 @@
     </select>
 
     <select id="getMultiFiltersAssignees" parameterType="java.util.Map"
-            resultType="codesquard.app.issue.mapper.response.filters.response.MultiFiltersAssignees">
+            resultType="codesquard.app.issue.mapper.response.filters.response.MultiFilterAssignee">
         SELECT id, login_id AS name, avatar_url AS avatarUrl
         <if test="check = true and request.assignee != null and request.assignee != 'none'">
             , (SELECT IF(login_id = #{request.assignee}, true, false)) AS `selected`
@@ -162,7 +162,7 @@
     </select>
 
     <select id="getMultiFiltersAuthors" parameterType="java.util.Map"
-            resultType="codesquard.app.issue.mapper.response.filters.response.MultiFiltersAuthors">
+            resultType="codesquard.app.issue.mapper.response.filters.response.MultiFilterAuthor">
         SELECT id, login_id AS name, avatar_url AS avatarUrl
         <if test="check = true and request.author != null">
             , (SELECT IF(login_id = #{request.author}, true, false)) AS `selected`
@@ -174,7 +174,7 @@
     </select>
 
     <select id="getMultiFiltersLabels" parameterType="java.util.Map"
-            resultType="codesquard.app.issue.mapper.response.filters.response.MultiFiltersLabels">
+            resultType="codesquard.app.issue.mapper.response.filters.response.MultiFilterLabel">
         SELECT id, name, color, background
         <if test="check = true and request.label != null and request.label.get(0) != 'none'">
             , (SELECT IF(name IN
@@ -190,7 +190,7 @@
     </select>
 
     <select id="getMultiFiltersMilestones" parameterType="java.util.Map"
-            resultType="codesquard.app.issue.mapper.response.filters.response.MultiFiltersMilestones">
+            resultType="codesquard.app.issue.mapper.response.filters.response.MultiFilterMilestone">
         SELECT id, name
         <if test="check = true and request.milestone != null and request.milestone != 'none'">
             , (SELECT IF(name = #{request.milestone}, true, false)) AS `selected`

--- a/backend/src/test/java/codesquard/app/issue/mapper/IssueMapperTest.java
+++ b/backend/src/test/java/codesquard/app/issue/mapper/IssueMapperTest.java
@@ -1,0 +1,273 @@
+package codesquard.app.issue.mapper;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import codesquard.app.IntegrationTestSupport;
+import codesquard.app.comment.entity.Comment;
+import codesquard.app.comment.repository.CommentRepository;
+import codesquard.app.issue.entity.Issue;
+import codesquard.app.issue.mapper.request.IssueFilterRequest;
+import codesquard.app.issue.mapper.response.IssuesResponse;
+import codesquard.app.issue.repository.IssueRepository;
+import codesquard.app.label.entity.Label;
+import codesquard.app.label.repository.LabelRepository;
+import codesquard.app.milestone.entity.Milestone;
+import codesquard.app.milestone.repository.MilestoneRepository;
+import codesquard.app.user.entity.User;
+import codesquard.app.user.repository.UserRepository;
+
+class IssueMapperTest extends IntegrationTestSupport {
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
+	@Autowired
+	private CommentRepository commentRepository;
+
+	@Autowired
+	private IssueMapper issueMapper;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private IssueRepository issueRepository;
+
+	@Autowired
+	private MilestoneRepository milestoneRepository;
+
+	@Autowired
+	private LabelRepository labelRepository;
+
+	@BeforeEach
+	void setUp() {
+		jdbcTemplate.update("SET FOREIGN_KEY_CHECKS = 0");
+		jdbcTemplate.update("TRUNCATE TABLE comment");
+		jdbcTemplate.update("TRUNCATE TABLE issue_assignee");
+		jdbcTemplate.update("TRUNCATE TABLE issue_label");
+		jdbcTemplate.update("TRUNCATE TABLE label");
+		jdbcTemplate.update("TRUNCATE TABLE issue");
+		jdbcTemplate.update("TRUNCATE TABLE milestone");
+		jdbcTemplate.update("TRUNCATE TABLE user");
+		jdbcTemplate.update("SET FOREIGN_KEY_CHECKS = 1");
+	}
+
+	@DisplayName("요청 파라미터가 없는 경우 'is:opened' 조건에 맞는 목록을 반환한다.")
+	@Test
+	void getIssuesWithNoParameter() {
+		// given
+		createUsersFixture();
+		createMilestonesFixture();
+		createIssuesFixture();
+
+		IssueFilterRequest issueFilterRequest = new IssueFilterRequest();
+
+		// when
+		final List<IssuesResponse> issues = issueMapper.getIssues(issueFilterRequest);
+
+		// then
+		assertThat(issues).hasSize(3);
+	}
+
+	@DisplayName("'author:user' 조건에 맞는 목록을 반환한다.")
+	@Test
+	void getIssuesWithAuthorFilter() {
+		// given
+		createUsersFixture();
+		createMilestonesFixture();
+		createIssuesFixture();
+
+		IssueFilterRequest issueFilterRequest = new IssueFilterRequest();
+		issueFilterRequest.setAuthor("user1");
+
+		// when
+		final List<IssuesResponse> issues = issueMapper.getIssues(issueFilterRequest);
+
+		// then
+		assertThat(issues).hasSize(1);
+	}
+
+	@DisplayName("'assignee:user' 조건에 맞는 목록을 반환한다.")
+	@CsvSource(value = {"user1,1", "user2,2", "user3,3"})
+	@ParameterizedTest
+	void getIssuesWithAssigneeFilter(String loginId, int count) {
+		// given
+		createUsersFixture();
+		createMilestonesFixture();
+		createIssuesFixture();
+		createIssuesAssigneesFixture();
+
+		IssueFilterRequest issueFilterRequest = new IssueFilterRequest();
+		issueFilterRequest.setAssignee(loginId);
+
+		// when
+		final List<IssuesResponse> issues = issueMapper.getIssues(issueFilterRequest);
+
+		// then
+		assertThat(issues).hasSize(count);
+	}
+
+	@DisplayName("'label:name' 조건에 맞는 목록을 반환한다.")
+	@CsvSource(value = {"feature,1", "docs,2", "bug,3"})
+	@ParameterizedTest
+	void getIssuesWithLabelFilter(String label, int count) {
+		// given
+		createUsersFixture();
+		createMilestonesFixture();
+		createIssuesFixture();
+		createLabelsFixture();
+		createIssuesLabelsFixture();
+
+		IssueFilterRequest issueFilterRequest = new IssueFilterRequest();
+		issueFilterRequest.setLabel(List.of(label));
+
+		// when
+		final List<IssuesResponse> issues = issueMapper.getIssues(issueFilterRequest);
+
+		// then
+		assertThat(issues).hasSize(count);
+	}
+
+	@DisplayName("'label:name' 다중 조건에 맞는 목록을 반환한다.")
+	@Test
+	void getIssuesWithMultiLabel() {
+		// given
+		createUsersFixture();
+		createMilestonesFixture();
+		createIssuesFixture();
+		createLabelsFixture();
+		createIssuesLabelsFixture();
+
+		IssueFilterRequest issueFilterRequest = new IssueFilterRequest();
+		issueFilterRequest.setLabel(List.of("docs", "bug"));
+
+		// when
+		final List<IssuesResponse> issues = issueMapper.getIssues(issueFilterRequest);
+
+		// then
+		assertThat(issues).hasSize(2);
+	}
+
+	@DisplayName("'milestone:name' 조건에 맞는 목록을 반환한다.")
+	@CsvSource(value = {"milestone1,1", "milestone2,2"})
+	@ParameterizedTest
+	void getIssuesWithMilestoneFilter(String milestone, int count) {
+		// given
+		createUsersFixture();
+		createMilestonesFixture();
+		createIssuesFixture();
+
+		IssueFilterRequest issueFilterRequest = new IssueFilterRequest();
+		issueFilterRequest.setMilestone(milestone);
+
+		// when
+		final List<IssuesResponse> issues = issueMapper.getIssues(issueFilterRequest);
+
+		// then
+		assertThat(issues).hasSize(count);
+	}
+
+	@DisplayName("'mentions:name' 조건에 맞는 목록을 반환한다.")
+	@CsvSource(value = {"user1,2", "user2,2", "user3,1"})
+	@ParameterizedTest
+	void getIssuesWithMention(String loginId, int count) {
+		// given
+		createUsersFixture();
+		createMilestonesFixture();
+		createIssuesFixture();
+		createCommentsFixture();
+
+		IssueFilterRequest issueFilterRequest = new IssueFilterRequest();
+		issueFilterRequest.setMentions(loginId);
+
+		// when
+		final List<IssuesResponse> issues = issueMapper.getIssues(issueFilterRequest);
+
+		// then
+		assertThat(issues).hasSize(count);
+	}
+
+	private void createUsersFixture() {
+		User user1 = new User(null, "user1", "user1@email.com", "password1000", "url path");
+		userRepository.save(user1);
+
+		User user2 = new User(null, "user2", "user2@email.com", "password1000", "url path");
+		userRepository.save(user2);
+
+		User user3 = new User(null, "user3", "user3@email.com", "password1000", "url path");
+		userRepository.save(user3);
+	}
+
+	private void createMilestonesFixture() {
+		Milestone milestone1 = new Milestone("milestone1", "week 1", null);
+		milestoneRepository.save(milestone1);
+
+		Milestone milestone2 = new Milestone("milestone2", "week 2", null);
+		milestoneRepository.save(milestone2);
+	}
+
+	private void createIssuesFixture() {
+		Issue issue1 = new Issue(1L, 1L, "test issue", "hello");
+		issueRepository.save(issue1);
+
+		Issue issue2 = new Issue(2L, 2L, "test issue", "hello");
+		issueRepository.save(issue2);
+
+		Issue issue3 = new Issue(2L, 3L, "test issue", "hello");
+		issueRepository.save(issue3);
+	}
+
+	private void createLabelsFixture() {
+		Label label1 = new Label("feature", "light", "#000000", "feature label");
+		labelRepository.save(label1);
+
+		Label label2 = new Label("docs", "light", "#000000", "docs label");
+		labelRepository.save(label2);
+
+		Label label3 = new Label("bug", "light", "#000000", "bugs label");
+		labelRepository.save(label3);
+	}
+
+	private void createIssuesLabelsFixture() {
+		issueRepository.saveIssueLabel(1L, List.of(1L, 2L, 3L));
+		issueRepository.saveIssueLabel(2L, List.of(2L, 3L));
+		issueRepository.saveIssueLabel(3L, List.of(3L));
+	}
+
+	private void createIssuesAssigneesFixture() {
+		issueRepository.saveIssueAssignee(1L, List.of(1L, 2L, 3L));
+		issueRepository.saveIssueAssignee(2L, List.of(2L, 3L));
+		issueRepository.saveIssueAssignee(3L, List.of(3L));
+	}
+
+	private void createCommentsFixture() {
+		LocalDateTime createdAt = LocalDateTime.of(2023, 9, 1, 16, 0);
+
+		Comment comment1 = new Comment(1L, 1L, "Create New Comment", createdAt);
+		commentRepository.save(comment1);
+
+		Comment comment2 = new Comment(1L, 2L, "Create New Comment", createdAt);
+		commentRepository.save(comment2);
+
+		Comment comment3 = new Comment(1L, 3L, "Create New Comment", createdAt);
+		commentRepository.save(comment3);
+
+		Comment comment4 = new Comment(2L, 1L, "Create New Comment", createdAt);
+		commentRepository.save(comment4);
+
+		Comment comment5 = new Comment(3L, 2L, "Create New Comment", createdAt);
+		commentRepository.save(comment5);
+	}
+
+}


### PR DESCRIPTION
## Description

MultiFilter Response에 다중 선택 가능 여부를 판단할 수 있는 데이터를 추가했습니다.

구조 변경 전
``` json
"multiFilters": {
            "assignees": [
                    {
                        "id": 1,
                        "name": "yeon",
                        "avatarUrl": "url path",
                        "selected": false
                    },
                    ...
```

구조 변경 후
``` json
"multiFilters": {
            "assignees": {
                "multipleSelect": false,
                "options": [
                    {
                        "id": 1,
                        "name": "yeon",
                        "avatarUrl": "url path",
                        "selected": false
                    },
                    ...
```

## Next Step

댓글 기능 관련 테스트 코드 수정 (로그인 필터 지나가기)
