### PR TITLE
[fe] 이슈, 댓글 CRUD 요청에 인증 토큰 추가

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -23,7 +23,7 @@ export function Header({ changeThemeMode }: { changeThemeMode: () => void }) {
       </Anchor>
       <HeaderRight>
         <Toggle onClick={changeThemeMode} />
-        <Avatar size="L" src={userInfo.avatarUrl} />
+        <Avatar size="L" src={userInfo.avatarUrl} userId={userInfo.loginId} />
         <Button size="S" buttonType="Ghost" onClick={logOut}>
           로그아웃
         </Button>

--- a/frontend/src/components/comment/CommentEditor.tsx
+++ b/frontend/src/components/comment/CommentEditor.tsx
@@ -46,6 +46,10 @@ export function CommentEditor({ issueId, fetchIssue }: CommentEditorProps) {
 
     await fetch("/api/comments", {
       method: "POST",
+      headers: {
+        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+        "credentials": "include",
+      },
       body: JSON.stringify({ issueId, content, userId: "jello000" }),
     });
 

--- a/frontend/src/components/comment/CommentEditor.tsx
+++ b/frontend/src/components/comment/CommentEditor.tsx
@@ -3,6 +3,7 @@ import { styled } from "styled-components";
 import { addCommasToNumber } from "../../utils/addCommasToNumber";
 import { Button } from "../Button";
 import { TextArea } from "../TextArea";
+import { getAccessToken } from "../../utils/localStorage";
 
 type CommentEditorProps = {
   issueId: number;
@@ -47,7 +48,7 @@ export function CommentEditor({ issueId, fetchIssue }: CommentEditorProps) {
     await fetch("/api/comments", {
       method: "POST",
       headers: {
-        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+        "Authorization": `Bearer ${getAccessToken()}`,
         "credentials": "include",
       },
       body: JSON.stringify({ issueId, content }),

--- a/frontend/src/components/comment/CommentEditor.tsx
+++ b/frontend/src/components/comment/CommentEditor.tsx
@@ -50,7 +50,7 @@ export function CommentEditor({ issueId, fetchIssue }: CommentEditorProps) {
         "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
         "credentials": "include",
       },
-      body: JSON.stringify({ issueId, content, userId: "jello000" }),
+      body: JSON.stringify({ issueId, content }),
     });
 
     setContent("");

--- a/frontend/src/components/comment/CommentItem.tsx
+++ b/frontend/src/components/comment/CommentItem.tsx
@@ -65,6 +65,10 @@ export function CommentItem({
   const deleteComment = async () => {
     await fetch(`/api/comments/${id}`, {
       method: "DELETE",
+      headers: {
+        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+        "credentials": "include",
+      },
     });
 
     fetchIssue();
@@ -88,6 +92,10 @@ export function CommentItem({
   const onEditConfirmClick = async () => {
     await fetch(`/api/comments/${id}`, {
       method: "PATCH",
+      headers: {
+        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+        "credentials": "include",
+      },
       body: JSON.stringify({
         content: content,
       }),

--- a/frontend/src/components/comment/CommentItem.tsx
+++ b/frontend/src/components/comment/CommentItem.tsx
@@ -6,6 +6,7 @@ import { Avatar } from "../Avatar";
 import { Button } from "../Button";
 import { InformationTag } from "../InformationTag";
 import { TextArea } from "../TextArea";
+import { getAccessToken } from "../../utils/localStorage";
 
 type CommentItemProps = {
   id: number;
@@ -67,7 +68,7 @@ export function CommentItem({
     await fetch(`/api/comments/${id}`, {
       method: "DELETE",
       headers: {
-        Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+        Authorization: `Bearer ${getAccessToken()}`,
         credentials: "include",
       },
     });
@@ -94,7 +95,7 @@ export function CommentItem({
     await fetch(`/api/comments/${id}`, {
       method: "PATCH",
       headers: {
-        Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+        Authorization: `Bearer ${getAccessToken()}`,
         credentials: "include",
       },
       body: JSON.stringify({

--- a/frontend/src/components/comment/CommentItem.tsx
+++ b/frontend/src/components/comment/CommentItem.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { styled, useTheme } from "styled-components";
 import { addCommasToNumber } from "../../utils/addCommasToNumber";
 import { getElapsedSince } from "../../utils/getElapsedSince";
+import { Avatar } from "../Avatar";
 import { Button } from "../Button";
 import { InformationTag } from "../InformationTag";
 import { TextArea } from "../TextArea";
@@ -66,13 +67,13 @@ export function CommentItem({
     await fetch(`/api/comments/${id}`, {
       method: "DELETE",
       headers: {
-        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
-        "credentials": "include",
+        Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+        credentials: "include",
       },
     });
 
     fetchIssue();
-  }
+  };
 
   const onEditButtonClick = () => {
     setIsEditing(true);
@@ -93,8 +94,8 @@ export function CommentItem({
     await fetch(`/api/comments/${id}`, {
       method: "PATCH",
       headers: {
-        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
-        "credentials": "include",
+        Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+        credentials: "include",
       },
       body: JSON.stringify({
         content: content,
@@ -117,15 +118,7 @@ export function CommentItem({
         onChange={onContentChange}
       >
         <WriterInfo>
-          {avatarUrl && (
-            <img
-              width="32"
-              height="32"
-              style={{ borderRadius: "50%" }}
-              src={avatarUrl}
-              alt="아바타"
-            />
-          )}
+          <Avatar size="L" src={avatarUrl} userId={userId} />
           <h3>{userId}</h3>
           <TimeStamp>{getElapsedSince(writtenAt)} 전</TimeStamp>
         </WriterInfo>

--- a/frontend/src/mocks/commentHandlers.ts
+++ b/frontend/src/mocks/commentHandlers.ts
@@ -1,12 +1,41 @@
 import { rest } from "msw";
-import { issue } from "./issueHandlers";
+import { issues } from "./issueHandlers";
+
+type Comment = {
+  id: number;
+  issueId: number;
+  userId: string;
+  avatarUrl: string | null;
+  content: string;
+  createdAt: string;
+  modifiedAt: string | null;
+  reactions: {
+    unicode: string;
+    users: string[];
+    selected: number | null;
+  }[];
+};
 
 export const commentHandlers = [
   rest.post("/api/comments", async (req, res, ctx) => {
-    const { content, userId } = await req.json();
+    const { issueId, content, userId } = await req.json();
+
+    const issue = issues.find((i) => i.id === issueId);
+
+    if (!issue) {
+      const notFoundError = {
+        code: 404,
+        status: "Not Found",
+        message: "이슈를 찾을 수 없습니다.",
+        data: null,
+      };
+
+      return res(ctx.status(404), ctx.json(notFoundError));
+    }
 
     const comment = {
-      id: issue.data.comments.length + 1,
+      id: Date.now(),
+      issueId,
       userId,
       avatarUrl: "https://pbs.twimg.com/media/EUplmpsU0AcR9jc.jpg",
       content,
@@ -15,68 +44,116 @@ export const commentHandlers = [
       reactions: [],
     };
 
-    issue.data = {
-      ...issue.data,
-      comments: [...issue.data.comments, comment],
+    comments.push(comment);
+
+    const response = {
+      code: 201,
+      status: "CREATED",
+      message: "댓글 등록에 성공했습니다.",
+      data: {
+        savedCommentId: comment.id,
+      },
     };
 
-    return res(
-      ctx.status(200),
-      ctx.json({
-        code: 201,
-        status: "CREATED",
-        message: "댓글 등록에 성공했습니다.",
-        data: {
-          savedCommentId: comment.id,
-        },
-      }),
-    );
+    return res(ctx.status(200), ctx.json(response));
   }),
   rest.patch("/api/comments/:commentId", async (req, res, ctx) => {
     const { commentId } = req.params;
     const { content } = await req.json();
 
-    issue.data = {
-      ...issue.data,
-      comments: issue.data.comments.map((comment) => {
-        return comment.id === Number(commentId)
-          ? { ...comment, content, modifiedAt: new Date().toISOString() }
-          : comment;
-      }),
+    const comment = comments.find(
+      (comment) => comment.id === Number(commentId),
+    );
+
+    if (!comment) {
+      const notFoundError = {
+        code: 404,
+        status: "Not Found",
+        message: "댓글을 찾을 수 없습니다.",
+        data: null,
+      };
+
+      return res(ctx.status(404), ctx.json(notFoundError));
+    }
+
+    comment.content = content;
+    comment.modifiedAt = new Date().toISOString();
+
+    const response = {
+      code: 200,
+      status: "OK",
+      message: "OK",
+      data: {
+        modifiedCommentId: comment.id,
+      },
     };
 
-    return res(
-      ctx.status(200),
-      ctx.json({
-        code: 200,
-        status: "OK",
-        message: "OK",
-        data: {
-          modifiedCommentId: Number(commentId),
-        },
-      }),
-    );
+    return res(ctx.status(200), ctx.json(response));
   }),
   rest.delete("/api/comments/:commentId", async (req, res, ctx) => {
     const { commentId } = req.params;
 
-    issue.data = {
-      ...issue.data,
-      comments: issue.data.comments.filter(
-        (comment) => comment.id !== Number(commentId),
-      ),
+    const comment = comments.findIndex(
+      (comment) => comment.id === Number(commentId),
+    );
+
+    if (comment === -1) {
+      const notFoundError = {
+        code: 404,
+        status: "Not Found",
+        message: "댓글을 찾을 수 없습니다.",
+        data: null,
+      };
+
+      return res(ctx.status(404), ctx.json(notFoundError));
+    }
+
+    const deletedComment = comments.splice(comment, 1);
+
+    const response = {
+      code: 200,
+      status: "OK",
+      message: "OK",
+      data: {
+        deletedCommentId: deletedComment[0].id,
+      },
     };
 
-    return res(
-      ctx.status(200),
-      ctx.json({
-        code: 200,
-        status: "OK",
-        message: "OK",
-        data: {
-          deletedCommentId: Number(commentId),
-        },
-      }),
-    );
-  })
-]
+    return res(ctx.status(200), ctx.json(response));
+  }),
+];
+
+export const comments: Comment[] = [
+  {
+    id: 3,
+    issueId: 2,
+    userId: "wis730",
+    avatarUrl:
+      "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT3j1RUWi4sAJkgFEdEFjtgvTOnd9kIpNZMp-GFc8zi&s",
+    content: "이 댓글을 읽은 당신은 앞으로 모든 일이 신기하게 잘풀립니다!",
+    createdAt: "2023-08-09T15:21:09",
+    modifiedAt: "2023-08-09T20:21:09",
+    reactions: [
+      {
+        unicode: "&#128077",
+        users: [],
+        selected: null,
+      },
+      {
+        unicode: "&#128078",
+        users: ["wis730"],
+        selected: 3,
+      },
+    ],
+  },
+  {
+    id: 5,
+    issueId: 2,
+    userId: "hjsong123",
+    avatarUrl: "https://pbs.twimg.com/media/EUplmpsU0AcR9jc.jpg",
+    content: "웃어보세요! 오늘 하루가 달라질 거에요!",
+    createdAt: "2023-08-10T10:21:09",
+    modifiedAt: "2023-08-10T13:21:09",
+    reactions: [],
+  },
+];

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -478,7 +478,7 @@ export const milestones = {
   },
 };
 
-const users: UsersData = [
+export const users: UsersData = [
   {
     user: {
       id: 0,

--- a/frontend/src/mocks/issueHandlers.ts
+++ b/frontend/src/mocks/issueHandlers.ts
@@ -1,5 +1,6 @@
 import { rest } from "msw";
 import { assignees } from "./assigneeHandlers";
+import { comments } from "./commentHandlers";
 import { labels, milestones } from "./handlers";
 
 type Issue = {
@@ -70,6 +71,18 @@ export const issueHandlers = [
 
       return res(ctx.status(404), ctx.json(notFoundError));
     }
+
+    issue.comments = comments
+      .filter((c) => c.issueId === Number(issueId))
+      .map((c) => ({
+        id: c.id,
+        userId: c.userId,
+        avatarUrl: c.avatarUrl,
+        content: c.content,
+        createdAt: c.createdAt,
+        modifiedAt: c.modifiedAt,
+        reactions: c.reactions,
+      }));
 
     const response = {
       code: 200,
@@ -234,10 +247,9 @@ export const issueHandlers = [
     return res(ctx.status(200), ctx.json(response));
   }),
   rest.patch("/api/issues/:issueId/assignees", async (req, res, ctx) => {
-    const {issueId} = req.params;
+    const { issueId } = req.params;
     const { assignees: assigneeIds } = await req.json();
 
-    
     const issue = issues.find((i) => i.id === Number(issueId));
 
     if (!issue) {
@@ -357,7 +369,7 @@ export const issueHandlers = [
 
       return res(ctx.status(404), ctx.json(notFoundError));
     }
-    
+
     const deletedIssue = issues.splice(issueIndex, 1);
 
     const response = {
@@ -367,16 +379,13 @@ export const issueHandlers = [
       data: {
         deletedIssueId: deletedIssue[0].id,
       },
-    }
+    };
 
-    return res(
-      ctx.status(200),
-      ctx.json(response),
-    );
+    return res(ctx.status(200), ctx.json(response));
   }),
 ];
 
-const issues: Issue[] = [
+export const issues: Issue[] = [
   {
     id: 2,
     title: "제목1",
@@ -430,38 +439,7 @@ const issues: Issue[] = [
       avatarUrl:
         "https://i.namu.wiki/i/2KCzxN-etRYFHRQVHH9-ROMgsOvyU3X4y7A2wuqNV5apHBn8APhnhPuapmrXewTuRcVtgos2UIAdHOCDkKVOFQ.webp",
     },
-    comments: [
-      {
-        id: 3,
-        userId: "wis730",
-        avatarUrl:
-          "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT3j1RUWi4sAJkgFEdEFjtgvTOnd9kIpNZMp-GFc8zi&s",
-        content: "이 댓글을 읽은 당신은 앞으로 모든 일이 신기하게 잘풀립니다!",
-        createdAt: "2023-08-09T15:21:09",
-        modifiedAt: "2023-08-09T20:21:09",
-        reactions: [
-          {
-            unicode: "&#128077",
-            users: [],
-            selected: null,
-          },
-          {
-            unicode: "&#128078",
-            users: ["wis730"],
-            selected: 3,
-          },
-        ],
-      },
-      {
-        id: 5,
-        userId: "hjsong123",
-        avatarUrl: "https://pbs.twimg.com/media/EUplmpsU0AcR9jc.jpg",
-        content: "웃어보세요! 오늘 하루가 달라질 거에요!",
-        createdAt: "2023-08-10T10:21:09",
-        modifiedAt: "2023-08-10T13:21:09",
-        reactions: [],
-      },
-    ],
+    comments: [],
   },
   {
     id: 5,
@@ -494,100 +472,3 @@ const issues: Issue[] = [
     comments: [],
   },
 ];
-
-export const issue: {
-  code: number;
-  status: string;
-  message: string;
-  data: Issue;
-} = {
-  code: 200,
-  status: "OK",
-  message: "OK",
-  data: {
-    id: 2,
-    title: "제목1",
-    status: "OPENED",
-    statusModifiedAt: "2023-08-09T06:01:37",
-    createdAt: "2023-08-09T06:01:37",
-    modifiedAt: "2023-08-10T06:01:37",
-    content: `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Egestas fringilla phasellus faucibus scelerisque eleifend donec. Ultricies mi quis hendrerit dolor magna eget. Purus ut faucibus pulvinar elementum integer. Suspendisse ultrices gravida dictum fusce ut placerat orci. Auctor elit sed vulputate mi sit. Egestas fringilla phasellus faucibus scelerisque eleifend donec. Egestas pretium aenean pharetra magna ac placerat vestibulum lectus. Nunc sed blandit libero volutpat. Elementum eu facilisis sed odio morbi quis commodo. Sed augue lacus viverra vitae congue eu consequat ac felis.
-
-      Eu volutpat odio facilisis mauris sit amet massa vitae. Ut eu sem integer vitae. Id leo in vitae turpis massa sed elementum tempus. Arcu non sodales neque sodales ut etiam. Arcu non odio euismod lacinia at quis risus sed. Eget mauris pharetra et ultrices neque ornare. Neque vitae tempus quam pellentesque nec nam. Nulla at volutpat diam ut venenatis tellus in metus. Faucibus in ornare quam viverra orci sagittis. Leo in vitae turpis massa sed elementum tempus. Augue mauris augue neque gravida in fermentum et sollicitudin ac. Lobortis elementum nibh tellus molestie nunc non blandit massa. Suspendisse in est ante in nibh mauris cursus. Sed lectus vestibulum mattis ullamcorper velit sed. Lectus proin nibh nisl condimentum id venenatis a condimentum vitae. At lectus urna duis convallis convallis tellus id. Scelerisque eleifend donec pretium vulputate. Est pellentesque elit ullamcorper dignissim cras tincidunt. Leo a diam sollicitudin tempor id eu nisl nunc mi.
-      
-      Magna sit amet purus gravida. Duis convallis convallis tellus id interdum velit laoreet id. Interdum consectetur libero id faucibus nisl tincidunt. Hac habitasse platea dictumst quisque sagittis purus sit amet. Tempus urna et pharetra pharetra massa. Egestas erat imperdiet sed euismod nisi porta lorem. Mauris pellentesque pulvinar pellentesque habitant morbi. Nibh ipsum consequat nisl vel pretium lectus quam. Purus sit amet luctus venenatis lectus magna fringilla urna porttitor. Vulputate sapien nec sagittis aliquam malesuada bibendum arcu. Imperdiet nulla malesuada pellentesque elit eget gravida cum sociis. Convallis posuere morbi leo urna molestie at elementum. Accumsan tortor posuere ac ut consequat semper viverra nam libero. Non tellus orci ac auctor augue mauris augue. Vulputate ut pharetra sit amet aliquam id. Id interdum velit laoreet id. Ut venenatis tellus in metus vulputate. Egestas sed tempus urna et pharetra pharetra massa massa ultricies. Tristique senectus et netus et malesuada fames ac turpis. A iaculis at erat pellentesque adipiscing commodo elit at.`,
-    reactions: [
-      {
-        unicode: "&#128077",
-        users: ["wis730", "wisdom"],
-        selectedUserReactionId: 1,
-      },
-      {
-        unicode: "&#128078",
-        users: [],
-        selectedUserReactionId: 0,
-      },
-    ],
-    assignees: [
-      {
-        id: 1,
-        name: "hong1234",
-        avatarUrl: null,
-      },
-    ],
-    labels: [
-      {
-        id: 2,
-        name: "documentation",
-        color: "LIGHT",
-        background: "#0025E6",
-      },
-    ],
-    milestone: {
-      id: 1,
-      name: "Sprint#1",
-      issues: {
-        openedIssueCount: 22,
-        closedIssueCount: 10,
-      },
-    },
-    writer: {
-      id: 1,
-      name: "wis730",
-      avatarUrl:
-        "https://i.namu.wiki/i/2KCzxN-etRYFHRQVHH9-ROMgsOvyU3X4y7A2wuqNV5apHBn8APhnhPuapmrXewTuRcVtgos2UIAdHOCDkKVOFQ.webp",
-    },
-    comments: [
-      {
-        id: 1,
-        userId: "wis730",
-        avatarUrl:
-          "https://i.namu.wiki/i/2KCzxN-etRYFHRQVHH9-ROMgsOvyU3X4y7A2wuqNV5apHBn8APhnhPuapmrXewTuRcVtgos2UIAdHOCDkKVOFQ.webp",
-        content: "이 댓글을 읽은 당신은 앞으로 모든 일이 신기하게 잘풀립니다!",
-        createdAt: "2023-08-09T15:21:09",
-        modifiedAt: "2023-08-09T20:21:09",
-        reactions: [
-          {
-            unicode: "&#128077",
-            users: [],
-            selected: null,
-          },
-          {
-            unicode: "&#128078",
-            users: ["wis730"],
-            selected: 3,
-          },
-        ],
-      },
-      {
-        id: 2,
-        userId: "hjsong123",
-        avatarUrl: "https://pbs.twimg.com/media/EUplmpsU0AcR9jc.jpg",
-        content: "웃어보세요! 오늘 하루가 달라질 거에요!",
-        createdAt: "2023-08-10T10:21:09",
-        modifiedAt: "2023-08-10T13:21:09",
-        reactions: [],
-      },
-    ],
-  },
-};

--- a/frontend/src/mocks/issueHandlers.ts
+++ b/frontend/src/mocks/issueHandlers.ts
@@ -206,115 +206,172 @@ export const issueHandlers = [
     const { issueId } = req.params;
     const { content } = await req.json();
 
-    issue.data = {
-      ...issue.data,
-      content,
-      modifiedAt: new Date().toISOString(),
+    const issue = issues.find((i) => i.id === Number(issueId));
+
+    if (!issue) {
+      const notFoundError = {
+        code: 404,
+        status: "Not Found",
+        message: "이슈를 찾을 수 없습니다.",
+        data: null,
+      };
+
+      return res(ctx.status(404), ctx.json(notFoundError));
+    }
+
+    issue.content = content;
+    issue.modifiedAt = new Date().toISOString();
+
+    const response = {
+      code: 200,
+      status: "OK",
+      message: "OK",
+      data: {
+        modifiedIssueId: issue.id,
+      },
     };
 
-    return res(
-      ctx.status(200),
-      ctx.json({
-        code: 200,
-        status: "OK",
-        message: "OK",
-        data: {
-          modifiedIssueId: Number(issueId),
-        },
-      }),
-    );
+    return res(ctx.status(200), ctx.json(response));
   }),
   rest.patch("/api/issues/:issueId/assignees", async (req, res, ctx) => {
-    const { issueId, assignees: assigneeIds } = await req.json();
+    const {issueId} = req.params;
+    const { assignees: assigneeIds } = await req.json();
 
-    issue.data = {
-      ...issue.data,
-      assignees: assigneeIds.map((id: number) => {
-        const assigneeData = assignees.data.assignees.find((a) => a.id === id)!;
+    
+    const issue = issues.find((i) => i.id === Number(issueId));
 
-        return {
-          id: assigneeData.id,
-          name: assigneeData.loginId,
-          avatarUrl: assigneeData.avatarUrl,
-        };
-      }),
+    if (!issue) {
+      const notFoundError = {
+        code: 404,
+        status: "Not Found",
+        message: "이슈를 찾을 수 없습니다.",
+        data: null,
+      };
+
+      return res(ctx.status(404), ctx.json(notFoundError));
+    }
+
+    issue.assignees = assigneeIds.map((id: number) => {
+      const assigneeData = assignees.data.assignees.find((a) => a.id === id)!;
+
+      return {
+        id: assigneeData.id,
+        name: assigneeData.loginId,
+        avatarUrl: assigneeData.avatarUrl,
+      };
+    });
+
+    const response = {
+      code: 200,
+      status: "OK",
+      messages: "OK",
+      data: {
+        modifiedIssueId: issue.id,
+      },
     };
 
-    return res(
-      ctx.status(200),
-      ctx.json({
-        code: 200,
-        status: "OK",
-        messages: "OK",
-        data: {
-          modifiedIssueId: issueId,
-        },
-      }),
-    );
+    return res(ctx.status(200), ctx.json(response));
   }),
   rest.patch("/api/issues/:issueId/labels", async (req, res, ctx) => {
-    const { issueId, labels: labelIds } = await req.json();
+    const { issueId } = req.params;
+    const { labels: labelIds } = await req.json();
 
-    issue.data = {
-      ...issue.data,
-      labels: labelIds.map((id: number) => {
-        const labelData = labels.data.labels.find((l) => l.id === id)!;
+    const issue = issues.find((i) => i.id === Number(issueId));
 
-        return {
-          id: labelData.id,
-          name: labelData.name,
-          color: labelData.color,
-          background: labelData.background,
-        };
-      }),
+    if (!issue) {
+      const notFoundError = {
+        code: 404,
+        status: "Not Found",
+        message: "이슈를 찾을 수 없습니다.",
+        data: null,
+      };
+
+      return res(ctx.status(404), ctx.json(notFoundError));
+    }
+
+    issue.labels = labelIds.map((id: number) => {
+      const labelData = labels.data.labels.find((l) => l.id === id)!;
+
+      return {
+        id: labelData.id,
+        name: labelData.name,
+        color: labelData.color,
+        background: labelData.background,
+      };
+    });
+
+    const response = {
+      code: 200,
+      status: "OK",
+      messages: "OK",
+      data: {
+        modifiedIssueId: issue.id,
+      },
     };
 
-    return res(
-      ctx.status(200),
-      ctx.json({
-        code: 200,
-        status: "OK",
-        messages: "OK",
-        data: {
-          modifiedIssueId: issueId,
-        },
-      }),
-    );
+    return res(ctx.status(200), ctx.json(response));
   }),
   rest.patch("/api/issues/:issueId/milestones", async (req, res, ctx) => {
-    const { issueId, milestone: milestoneId } = await req.json();
+    const { issueId } = req.params;
+    const { milestone: milestoneId } = await req.json();
 
-    issue.data = {
-      ...issue.data,
-      milestone:
-        milestones.data.milestones.find((m) => m.id === milestoneId) ?? null,
+    const issue = issues.find((i) => i.id === Number(issueId));
+
+    if (!issue) {
+      const notFoundError = {
+        code: 404,
+        status: "Not Found",
+        message: "이슈를 찾을 수 없습니다.",
+        data: null,
+      };
+
+      return res(ctx.status(404), ctx.json(notFoundError));
+    }
+
+    issue.milestone =
+      milestones.data.milestones.find((m) => m.id === milestoneId) ?? null;
+
+    const response = {
+      code: 200,
+      status: "OK",
+      messages: "OK",
+      data: {
+        modifiedIssueId: issue.id,
+      },
     };
 
-    return res(
-      ctx.status(200),
-      ctx.json({
-        code: 200,
-        status: "OK",
-        messages: "OK",
-        data: {
-          modifiedIssueId: issueId,
-        },
-      }),
-    );
+    return res(ctx.status(200), ctx.json(response));
   }),
   rest.delete("/api/issues/:issueId", async (req, res, ctx) => {
     const { issueId } = req.params;
 
+    const issueIndex = issues.findIndex((i) => i.id === Number(issueId));
+
+    if (issueIndex === -1) {
+      const notFoundError = {
+        code: 404,
+        status: "Not Found",
+        message: "이슈를 찾을 수 없습니다.",
+        data: null,
+      };
+
+      return res(ctx.status(404), ctx.json(notFoundError));
+    }
+    
+    const deletedIssue = issues.splice(issueIndex, 1);
+
+    const response = {
+      code: 200,
+      status: "OK",
+      messages: "OK",
+      data: {
+        deletedIssueId: deletedIssue[0].id,
+      },
+    }
+
     return res(
       ctx.status(200),
-      ctx.json({
-        code: 200,
-        status: "OK",
-        messages: "OK",
-        data: {
-          deletedIssueId: issueId,
-        },
-      }),
+      ctx.json(response),
     );
   }),
 ];

--- a/frontend/src/mocks/issueHandlers.ts
+++ b/frontend/src/mocks/issueHandlers.ts
@@ -55,8 +55,92 @@ type Issue = {
 };
 
 export const issueHandlers = [
-  rest.get("/api/issues/:issueId", (_, res, ctx) => {
-    return res(ctx.status(200), ctx.json(issue));
+  rest.get("/api/issues/:issueId", (req, res, ctx) => {
+    const { issueId } = req.params;
+
+    const issue = issues.find((i) => i.id === Number(issueId));
+    
+    if (!issue) {
+      return res(
+        ctx.status(404),
+        ctx.json({
+          code: 404,
+          status: "Not Found",
+          message: "이슈를 찾을 수 없습니다.",
+          data: null,
+        }),
+      );
+    }
+    return res(
+      ctx.status(200),
+      ctx.json({
+        code: 200,
+        status: "OK",
+        message: "OK",
+        data: issue,
+      }),
+    );
+  }),
+  rest.post("/api/issues", async (req, res, ctx) => {
+    const {
+      title,
+      content,
+      milestone: milestoneId,
+      labels: labelIds,
+      assignees: assigneeIds,
+    } = await req.json();
+
+    const newIssue: Issue = {
+      id: Date.now(),
+      title,
+      content,
+      status: "OPENED",
+      statusModifiedAt: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+      modifiedAt: null,
+      reactions: [],
+      assignees: assigneeIds.map((id: number) => {
+        const assigneeData = assignees.data.assignees.find((a) => a.id === id)!;
+
+        return {
+          id: assigneeData.id,
+          name: assigneeData.loginId,
+          avatarUrl: assigneeData.avatarUrl,
+        };
+      }),
+      labels: labelIds.map((id: number) => {
+        const labelData = labels.data.labels.find((l) => l.id === id)!;
+
+        return {
+          id: labelData.id,
+          name: labelData.name,
+          color: labelData.color,
+          background: labelData.background,
+        };
+      }),
+      milestone:
+        milestones.data.milestones.find((m) => m.id === milestoneId) ?? null,
+      writer: {
+        id: 0,
+        name: "test123",
+        avatarUrl: "https://avatars.githubusercontent.com/u/41321198?v=4",
+      },
+      comments: [],
+    };
+
+    issues.push(newIssue);
+
+    return res(
+      ctx.status(201),
+      ctx.json({
+        code: 201,
+        status: "CREATED",
+        message: "이슈 등록에 성공했습니다.",
+        data: {
+          savedIssueId: newIssue.id,
+        },
+      }),
+    );
   }),
   rest.patch("/api/issues/:issueId/title", async (req, res, ctx) => {
     const { issueId } = req.params;
@@ -213,6 +297,125 @@ export const issueHandlers = [
       }),
     );
   }),
+];
+
+const issues: Issue[] = [
+  {
+    id: 2,
+    title: "제목1",
+    status: "OPENED",
+    statusModifiedAt: "2023-08-09T06:01:37",
+    createdAt: "2023-08-09T06:01:37",
+    modifiedAt: "2023-08-10T06:01:37",
+    content: `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Egestas fringilla phasellus faucibus scelerisque eleifend donec. Ultricies mi quis hendrerit dolor magna eget. Purus ut faucibus pulvinar elementum integer. Suspendisse ultrices gravida dictum fusce ut placerat orci. Auctor elit sed vulputate mi sit. Egestas fringilla phasellus faucibus scelerisque eleifend donec. Egestas pretium aenean pharetra magna ac placerat vestibulum lectus. Nunc sed blandit libero volutpat. Elementum eu facilisis sed odio morbi quis commodo. Sed augue lacus viverra vitae congue eu consequat ac felis.
+
+      Eu volutpat odio facilisis mauris sit amet massa vitae. Ut eu sem integer vitae. Id leo in vitae turpis massa sed elementum tempus. Arcu non sodales neque sodales ut etiam. Arcu non odio euismod lacinia at quis risus sed. Eget mauris pharetra et ultrices neque ornare. Neque vitae tempus quam pellentesque nec nam. Nulla at volutpat diam ut venenatis tellus in metus. Faucibus in ornare quam viverra orci sagittis. Leo in vitae turpis massa sed elementum tempus. Augue mauris augue neque gravida in fermentum et sollicitudin ac. Lobortis elementum nibh tellus molestie nunc non blandit massa. Suspendisse in est ante in nibh mauris cursus. Sed lectus vestibulum mattis ullamcorper velit sed. Lectus proin nibh nisl condimentum id venenatis a condimentum vitae. At lectus urna duis convallis convallis tellus id. Scelerisque eleifend donec pretium vulputate. Est pellentesque elit ullamcorper dignissim cras tincidunt. Leo a diam sollicitudin tempor id eu nisl nunc mi.
+      
+      Magna sit amet purus gravida. Duis convallis convallis tellus id interdum velit laoreet id. Interdum consectetur libero id faucibus nisl tincidunt. Hac habitasse platea dictumst quisque sagittis purus sit amet. Tempus urna et pharetra pharetra massa. Egestas erat imperdiet sed euismod nisi porta lorem. Mauris pellentesque pulvinar pellentesque habitant morbi. Nibh ipsum consequat nisl vel pretium lectus quam. Purus sit amet luctus venenatis lectus magna fringilla urna porttitor. Vulputate sapien nec sagittis aliquam malesuada bibendum arcu. Imperdiet nulla malesuada pellentesque elit eget gravida cum sociis. Convallis posuere morbi leo urna molestie at elementum. Accumsan tortor posuere ac ut consequat semper viverra nam libero. Non tellus orci ac auctor augue mauris augue. Vulputate ut pharetra sit amet aliquam id. Id interdum velit laoreet id. Ut venenatis tellus in metus vulputate. Egestas sed tempus urna et pharetra pharetra massa massa ultricies. Tristique senectus et netus et malesuada fames ac turpis. A iaculis at erat pellentesque adipiscing commodo elit at.`,
+    reactions: [
+      {
+        unicode: "&#128077",
+        users: ["wis730", "wisdom"],
+        selectedUserReactionId: 1,
+      },
+      {
+        unicode: "&#128078",
+        users: [],
+        selectedUserReactionId: 0,
+      },
+    ],
+    assignees: [
+      {
+        id: 1,
+        name: "hong1234",
+        avatarUrl: null,
+      },
+    ],
+    labels: [
+      {
+        id: 2,
+        name: "documentation",
+        color: "LIGHT",
+        background: "#0025E6",
+      },
+    ],
+    milestone: {
+      id: 1,
+      name: "Sprint#1",
+      issues: {
+        openedIssueCount: 22,
+        closedIssueCount: 10,
+      },
+    },
+    writer: {
+      id: 1,
+      name: "hong1234",
+      avatarUrl:
+        "https://i.namu.wiki/i/2KCzxN-etRYFHRQVHH9-ROMgsOvyU3X4y7A2wuqNV5apHBn8APhnhPuapmrXewTuRcVtgos2UIAdHOCDkKVOFQ.webp",
+    },
+    comments: [
+      {
+        id: 3,
+        userId: "wis730",
+        avatarUrl:
+          "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcT3j1RUWi4sAJkgFEdEFjtgvTOnd9kIpNZMp-GFc8zi&s",
+        content: "이 댓글을 읽은 당신은 앞으로 모든 일이 신기하게 잘풀립니다!",
+        createdAt: "2023-08-09T15:21:09",
+        modifiedAt: "2023-08-09T20:21:09",
+        reactions: [
+          {
+            unicode: "&#128077",
+            users: [],
+            selected: null,
+          },
+          {
+            unicode: "&#128078",
+            users: ["wis730"],
+            selected: 3,
+          },
+        ],
+      },
+      {
+        id: 5,
+        userId: "hjsong123",
+        avatarUrl: "https://pbs.twimg.com/media/EUplmpsU0AcR9jc.jpg",
+        content: "웃어보세요! 오늘 하루가 달라질 거에요!",
+        createdAt: "2023-08-10T10:21:09",
+        modifiedAt: "2023-08-10T13:21:09",
+        reactions: [],
+      },
+    ],
+  },
+  {
+    id: 5,
+    title: "테스트",
+    status: "OPENED",
+    statusModifiedAt: "2023-08-09T06:01:37",
+    createdAt: "2023-08-09T06:01:37",
+    modifiedAt: "2023-08-10T06:01:37",
+    content: `테스트`,
+    reactions: [
+      {
+        unicode: "&#128077",
+        users: ["wis730", "wisdom"],
+        selectedUserReactionId: 1,
+      },
+      {
+        unicode: "&#128078",
+        users: [],
+        selectedUserReactionId: 0,
+      },
+    ],
+    assignees: [],
+    labels: [],
+    milestone: null,
+    writer: {
+      id: 2,
+      name: "lee1234",
+      avatarUrl: "https://pbs.twimg.com/media/EUplmpsU0AcR9jc.jpg",
+    },
+    comments: [],
+  },
 ];
 
 export const issue: {

--- a/frontend/src/mocks/issueHandlers.ts
+++ b/frontend/src/mocks/issueHandlers.ts
@@ -59,27 +59,26 @@ export const issueHandlers = [
     const { issueId } = req.params;
 
     const issue = issues.find((i) => i.id === Number(issueId));
-    
+
     if (!issue) {
-      return res(
-        ctx.status(404),
-        ctx.json({
-          code: 404,
-          status: "Not Found",
-          message: "이슈를 찾을 수 없습니다.",
-          data: null,
-        }),
-      );
+      const notFoundError = {
+        code: 404,
+        status: "Not Found",
+        message: "이슈를 찾을 수 없습니다.",
+        data: null,
+      };
+
+      return res(ctx.status(404), ctx.json(notFoundError));
     }
-    return res(
-      ctx.status(200),
-      ctx.json({
-        code: 200,
-        status: "OK",
-        message: "OK",
-        data: issue,
-      }),
-    );
+
+    const response = {
+      code: 200,
+      status: "OK",
+      message: "OK",
+      data: issue,
+    };
+
+    return res(ctx.status(200), ctx.json(response));
   }),
   rest.post("/api/issues", async (req, res, ctx) => {
     const {
@@ -146,41 +145,62 @@ export const issueHandlers = [
     const { issueId } = req.params;
     const { title } = await req.json();
 
-    issue.data.title = title;
+    const issue = issues.find((i) => i.id === Number(issueId));
 
-    return res(
-      ctx.status(200),
-      ctx.json({
-        code: 200,
-        status: "OK",
-        message: "OK",
-        data: {
-          modifiedIssueId: Number(issueId),
-        },
-      }),
-    );
+    if (!issue) {
+      const notFoundError = {
+        code: 404,
+        status: "Not Found",
+        message: "이슈를 찾을 수 없습니다.",
+        data: null,
+      };
+
+      return res(ctx.status(404), ctx.json(notFoundError));
+    }
+
+    issue.title = title;
+
+    const response = {
+      code: 200,
+      status: "OK",
+      message: "OK",
+      data: {
+        modifiedIssueId: issue.id,
+      },
+    };
+
+    return res(ctx.status(200), ctx.json(response));
   }),
   rest.patch("/api/issues/:issueId/status", async (req, res, ctx) => {
     const { issueId } = req.params;
     const { status } = await req.json();
 
-    issue.data = {
-      ...issue.data,
-      status,
-      statusModifiedAt: new Date().toISOString(),
+    const issue = issues.find((i) => i.id === Number(issueId));
+
+    if (!issue) {
+      const notFoundError = {
+        code: 404,
+        status: "Not Found",
+        message: "이슈를 찾을 수 없습니다.",
+        data: null,
+      };
+
+      return res(ctx.status(404), ctx.json(notFoundError));
+    }
+
+    issue.status = status;
+    issue.statusModifiedAt = new Date().toISOString();
+
+    const response = {
+      code: 200,
+      status: "OK",
+      message: "OK",
+      data: {
+        modifiedIssueId: issue.id,
+      },
     };
 
-    return res(
-      ctx.status(200),
-      ctx.json({
-        code: 200,
-        status: "OK",
-        message: "OK",
-        data: {
-          modifiedIssueId: Number(issueId),
-        },
-      }),
-    );
+    return res(ctx.status(200), ctx.json(response));
   }),
   rest.patch("/api/issues/:issueId/content", async (req, res, ctx) => {
     const { issueId } = req.params;

--- a/frontend/src/page/issueDetail/IssueContent.tsx
+++ b/frontend/src/page/issueDetail/IssueContent.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { styled } from "styled-components";
+import { Avatar } from "../../components/Avatar";
 import { Button } from "../../components/Button";
 import { InformationTag } from "../../components/InformationTag";
 import { TextArea } from "../../components/TextArea";
@@ -63,8 +64,8 @@ export function IssueContent({
     await fetch(`/api/issues/${id}/content`, {
       method: "PATCH",
       headers: {
-        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
-        "credentials": "include",
+        Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+        credentials: "include",
       },
       body: JSON.stringify({
         content: content,
@@ -87,15 +88,7 @@ export function IssueContent({
         onChange={onContentChange}
       >
         <WriterInfo>
-          {writer.avatarUrl && (
-            <img
-              width="32"
-              height="32"
-              style={{ borderRadius: "50%" }}
-              src={writer.avatarUrl}
-              alt="아바타"
-            />
-          )}
+          <Avatar size="L" src={writer.avatarUrl} userId={writer.name} />
           <h3>{writer.name}</h3>
           <TimeStamp>{getElapsedSince(writtenAt)} 전</TimeStamp>
         </WriterInfo>

--- a/frontend/src/page/issueDetail/IssueContent.tsx
+++ b/frontend/src/page/issueDetail/IssueContent.tsx
@@ -7,6 +7,7 @@ import { TextArea } from "../../components/TextArea";
 import { addCommasToNumber } from "../../utils/addCommasToNumber";
 import { getElapsedSince } from "../../utils/getElapsedSince";
 import { IssueDetailMainContentProps } from "./IssueDetailMainContent";
+import { getAccessToken } from "../../utils/localStorage";
 
 type IssueContentProps = Omit<IssueDetailMainContentProps, "comments">;
 
@@ -64,7 +65,7 @@ export function IssueContent({
     await fetch(`/api/issues/${id}/content`, {
       method: "PATCH",
       headers: {
-        Authorization: `Bearer ${localStorage.getItem("accessToken")}`,
+        Authorization: `Bearer ${getAccessToken()}`,
         credentials: "include",
       },
       body: JSON.stringify({

--- a/frontend/src/page/issueDetail/IssueContent.tsx
+++ b/frontend/src/page/issueDetail/IssueContent.tsx
@@ -62,6 +62,10 @@ export function IssueContent({
   const onEditConfirmClick = async () => {
     await fetch(`/api/issues/${id}/content`, {
       method: "PATCH",
+      headers: {
+        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+        "credentials": "include",
+      },
       body: JSON.stringify({
         content: content,
       }),

--- a/frontend/src/page/issueDetail/IssueDetail.tsx
+++ b/frontend/src/page/issueDetail/IssueDetail.tsx
@@ -93,21 +93,19 @@ export function IssueDetail() {
   });
 
   const fetchIssue = useCallback(async () => {
-    try {
-      const response = await fetch(`/api/issues/${issueId}`, {
-        headers: {
-          "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
-          "credentials": "include",
-        },
-      });
-      const result = await response.json();
+    const response = await fetch(`/api/issues/${issueId}`, {
+      headers: {
+        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+        "credentials": "include",
+      },
+    });
+    const result = await response.json();
 
-      if (result.code === 404) {
-        throw new Error(result.message);
-      }
-
+    if (result.code === 200) {
       setIssue(result.data);
-    } catch (error) {
+      return;
+    }
+    if (result.code === 404) {
       navigatte("/404", { replace: true });
     }
   }, [issueId, navigatte]);

--- a/frontend/src/page/issueDetail/IssueDetail.tsx
+++ b/frontend/src/page/issueDetail/IssueDetail.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { styled } from "styled-components";
 import { IssueDetailBody } from "./IssueDetailBody";
 import { IssueDetailHeader } from "./IssueDetailHeader";
+import { getAccessToken } from "../../utils/localStorage";
 
 export type IssueData = {
   id: number;
@@ -95,7 +96,7 @@ export function IssueDetail() {
   const fetchIssue = useCallback(async () => {
     const response = await fetch(`/api/issues/${issueId}`, {
       headers: {
-        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+        "Authorization": `Bearer ${getAccessToken()}`,
         "credentials": "include",
       },
     });

--- a/frontend/src/page/issueDetail/IssueDetail.tsx
+++ b/frontend/src/page/issueDetail/IssueDetail.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { styled } from "styled-components";
 import { IssueDetailBody } from "./IssueDetailBody";
 import { IssueDetailHeader } from "./IssueDetailHeader";
@@ -52,11 +52,12 @@ export type IssueData = {
       unicode: string;
       users: string[];
       selectedUserReactionId: number;
-    }[]
+    }[];
   }[];
 };
 
 export function IssueDetail() {
+  const navigatte = useNavigate();
   const { issueId } = useParams();
   const [issue, setIssue] = useState<IssueData>({
     id: 0,
@@ -66,11 +67,13 @@ export function IssueDetail() {
     statusModifiedAt: new Date(),
     createdAt: new Date(),
     modifiedAt: null,
-    reactions: [{
-      unicode: "",
-      users: [],
-      selectedUserReactionId: 0
-    }],
+    reactions: [
+      {
+        unicode: "",
+        users: [],
+        selectedUserReactionId: 0,
+      },
+    ],
     writer: {
       id: 0,
       name: "",
@@ -90,11 +93,24 @@ export function IssueDetail() {
   });
 
   const fetchIssue = useCallback(async () => {
-    const response = await fetch(`/api/issues/${issueId}`);
-    const result = await response.json();
+    try {
+      const response = await fetch(`/api/issues/${issueId}`, {
+        headers: {
+          "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+          "credentials": "include",
+        },
+      });
+      const result = await response.json();
 
-    setIssue(result.data);
-  }, [issueId]);
+      if (result.code === 404) {
+        throw new Error(result.message);
+      }
+
+      setIssue(result.data);
+    } catch (error) {
+      navigatte("/404", { replace: true });
+    }
+  }, [issueId, navigatte]);
 
   useEffect(() => {
     fetchIssue();

--- a/frontend/src/page/issueDetail/IssueDetailSidePanel.tsx
+++ b/frontend/src/page/issueDetail/IssueDetailSidePanel.tsx
@@ -21,6 +21,10 @@ export function IssueDetailSidePanel({
   const patchIssueAssignees = async (ids: number[]) => {
     await fetch(`/api/issues/${issueId}/assignees`, {
       method: "PATCH",
+      headers: {
+        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+        "credentials": "include",
+      },
       body: JSON.stringify({
         assignees: ids,
       }),
@@ -32,6 +36,10 @@ export function IssueDetailSidePanel({
   const patchIssueLabels = async (ids: number[]) => {
     await fetch(`/api/issues/${issueId}/labels`, {
       method: "PATCH",
+      headers: {
+        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+        "credentials": "include",
+      },
       body: JSON.stringify({
         labels: ids,
       }),
@@ -43,6 +51,10 @@ export function IssueDetailSidePanel({
   const patchIssueMilestone = async (id: number | null) => {
     await fetch(`/api/issues/${issueId}/milestones`, {
       method: "PATCH",
+      headers: {
+        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+        "credentials": "include",
+      },
       body: JSON.stringify({
         milestone: id,
       }),
@@ -54,6 +66,10 @@ export function IssueDetailSidePanel({
   const deleteIssue = async () => {
     await fetch(`/api/issues/${issueId}`, {
       method: "DELETE",
+      headers: {
+        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+        "credentials": "include",
+      },
     });
 
     navigate("/");

--- a/frontend/src/page/issueDetail/IssueDetailSidePanel.tsx
+++ b/frontend/src/page/issueDetail/IssueDetailSidePanel.tsx
@@ -3,6 +3,7 @@ import { Button } from "../../components/Button";
 import { Sidebar } from "../../components/sidebar/Sidebar";
 import { useNavigate } from "react-router-dom";
 import { IssueData } from "./IssueDetail";
+import { getAccessToken } from "../../utils/localStorage";
 
 type IssueDetailSidePanelProps = {
   fetchIssue: () => void;
@@ -22,7 +23,7 @@ export function IssueDetailSidePanel({
     await fetch(`/api/issues/${issueId}/assignees`, {
       method: "PATCH",
       headers: {
-        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+        "Authorization": `Bearer ${getAccessToken()}`,
         "credentials": "include",
       },
       body: JSON.stringify({
@@ -37,7 +38,7 @@ export function IssueDetailSidePanel({
     await fetch(`/api/issues/${issueId}/labels`, {
       method: "PATCH",
       headers: {
-        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+        "Authorization": `Bearer ${getAccessToken()}`,
         "credentials": "include",
       },
       body: JSON.stringify({
@@ -52,7 +53,7 @@ export function IssueDetailSidePanel({
     await fetch(`/api/issues/${issueId}/milestones`, {
       method: "PATCH",
       headers: {
-        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+        "Authorization": `Bearer ${getAccessToken()}`,
         "credentials": "include",
       },
       body: JSON.stringify({
@@ -67,7 +68,7 @@ export function IssueDetailSidePanel({
     await fetch(`/api/issues/${issueId}`, {
       method: "DELETE",
       headers: {
-        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+        "Authorization": `Bearer ${getAccessToken()}`,
         "credentials": "include",
       },
     });

--- a/frontend/src/page/issueDetail/IssueDetailTitleInfo.tsx
+++ b/frontend/src/page/issueDetail/IssueDetailTitleInfo.tsx
@@ -3,6 +3,7 @@ import { styled } from "styled-components";
 import { Button } from "../../components/Button";
 import { TextInput } from "../../components/TextInput";
 import { IssueDetailHeaderProps } from "./IssueDetailHeader";
+import { getAccessToken } from "../../utils/localStorage";
 
 type IssueDetailTitleProps = Omit<
   IssueDetailHeaderProps,
@@ -42,7 +43,7 @@ export function IssueDetailTitleInfo({
     await fetch(`/api/issues/${id}/title`, {
       method: "PATCH",
       headers: {
-        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+        "Authorization": `Bearer ${getAccessToken()}`,
         "credentials": "include",
       },
       body: JSON.stringify({ title }),
@@ -56,7 +57,7 @@ export function IssueDetailTitleInfo({
     await fetch(`/api/issues/${id}/status`, {
       method: "PATCH",
       headers: {
-        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+        "Authorization": `Bearer ${getAccessToken()}`,
         "credentials": "include",
       },
       body: JSON.stringify({

--- a/frontend/src/page/issueDetail/IssueDetailTitleInfo.tsx
+++ b/frontend/src/page/issueDetail/IssueDetailTitleInfo.tsx
@@ -41,6 +41,10 @@ export function IssueDetailTitleInfo({
   const onEditClick = async () => {
     await fetch(`/api/issues/${id}/title`, {
       method: "PATCH",
+      headers: {
+        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+        "credentials": "include",
+      },
       body: JSON.stringify({ title }),
     });
 
@@ -51,6 +55,10 @@ export function IssueDetailTitleInfo({
   const onStatusChangeClick = async () => {
     await fetch(`/api/issues/${id}/status`, {
       method: "PATCH",
+      headers: {
+        "Authorization": `Bearer ${localStorage.getItem("accessToken")}`,
+        "credentials": "include",
+      },
       body: JSON.stringify({
         status: status === "OPENED" ? "CLOSED" : "OPENED",
       }),

--- a/frontend/src/page/newIssue/NewIssue.tsx
+++ b/frontend/src/page/newIssue/NewIssue.tsx
@@ -6,6 +6,7 @@ import { IssueLabel } from "../../components/sidebar/AddLabel";
 import { IssueMilestone } from "../../components/sidebar/AddMilestone";
 import { NewIssueBody } from "./NewIssueBody";
 import { NewIssueFooter } from "./NewIssueFooter";
+import { getAccessToken } from "../../utils/localStorage";
 
 export function NewIssue() {
   const navigate = useNavigate();
@@ -15,15 +16,11 @@ export function NewIssue() {
   const [milestone, setMilestone] = useState<IssueMilestone | null>(null);
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
-  const [invalidTitle, setInvalidTitle] = useState(false);
 
-  const onTitleFocus = () => {
-    setInvalidTitle(title.length === 0);
-  };
+  const invalidTitle = title.length === 0;
 
   const onTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTitle(e.target.value);
-    setInvalidTitle(e.target.value.length === 0);
   };
 
   const onContentChange = (value: string) => {
@@ -49,12 +46,23 @@ export function NewIssue() {
     const issueData = {
       title: title,
       content: content,
-      assignees: assignees,
-      labels: labels,
-      milestone: milestone,
+      assignees: assignees.map((assignee) => assignee.id),
+      labels: labels.map((label) => label.id),
+      milestone: milestone?.id ?? null,
     };
 
-    console.log("이슈 등록 데이터", issueData);
+    const response = await fetch("/api/issues", {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${getAccessToken()}`
+      },
+      body: JSON.stringify(issueData),
+    })
+    const result = await response.json();
+
+    if (result.code === 201) {
+      navigate(`/issues/${result.data.savedIssueId}`);
+    }
   };
 
   const onCancelButtonClick = () => {
@@ -76,7 +84,6 @@ export function NewIssue() {
         onLabelClick={{ args: "DataArray", handler: updateIssueLabels }}
         onMilestoneClick={{ args: "Data", handler: updateIssueMilestone }}
         onTitleChange={onTitleChange}
-        onTitleFocus={onTitleFocus}
         onContentChange={onContentChange}
       />
       <Line />

--- a/frontend/src/page/newIssue/NewIssue.tsx
+++ b/frontend/src/page/newIssue/NewIssue.tsx
@@ -54,7 +54,8 @@ export function NewIssue() {
     const response = await fetch("/api/issues", {
       method: "POST",
       headers: {
-        "Authorization": `Bearer ${getAccessToken()}`
+        "Authorization": `Bearer ${getAccessToken()}`,
+        "credentials": "include",
       },
       body: JSON.stringify(issueData),
     })

--- a/frontend/src/page/newIssue/NewIssueBody.tsx
+++ b/frontend/src/page/newIssue/NewIssueBody.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { styled } from "styled-components";
 import { Avatar } from "../../components/Avatar";
 import { TextArea } from "../../components/TextArea";
@@ -9,7 +10,6 @@ type NewIssueBodyProps = {
   content: string;
   invalidTitle: boolean;
   onTitleChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  onTitleFocus: () => void;
   onContentChange: (value: string) => void;
 } & SidebarProps;
 
@@ -18,13 +18,19 @@ export function NewIssueBody({
   content,
   invalidTitle,
   onTitleChange,
-  onTitleFocus,
   onContentChange,
   ...rest
 }: NewIssueBodyProps) {
-  const titleCaption = invalidTitle
-    ? "제목은 1글자 이상 50글자 이하로 작성해주세요."
-    : "";
+  const [isFocused, setIsFocused] = useState(false);
+
+  const titleCaption =
+    isFocused && invalidTitle
+      ? "제목은 1글자 이상 50글자 이하로 작성해주세요."
+      : "";
+
+  const onTitleFocus = () => {
+    setIsFocused(true);
+  };
 
   return (
     <Div>
@@ -39,7 +45,7 @@ export function NewIssueBody({
           label="제목"
           value={title}
           maxLength={50}
-          isError={invalidTitle}
+          isError={isFocused && invalidTitle}
           caption={titleCaption}
           onChange={onTitleChange}
           onFocus={onTitleFocus}


### PR DESCRIPTION
## Description

- HTTP 요청 헤더에 인증 토큰(`Authorization`)과 리프레쉬 토큰을 위한 옵션(`credentials: "include"`)을 추가했습니다.
- msw 이슈, 댓글 데이터를 관리하는 방식을 변경했습니다.
  - 등록하기 전에 토큰으로 사용자를 검색해서 인증 후 응답합니다.
  - issues(handler.ts와는 다른 이슈 상세 페이지만을 위한 배열), comments 배열을 두고 찾아서 수정, 삭제를 진행

## To Reviewers

- 예외처리는 이슈 상세 페이지의 응답이 `code: 404`가 나왔을 때 404페이지로 보내는 처리만 했습니다.
- 이슈, 댓글 내용 작성자 아바타를 Avatar 컴포넌트로 교체했습니다. 헤더 아바타와 색상 일치를 위해 헤더쪽에 userId prop을 추가 전달했습니다.
- 이제 작성이 완료되면 해당 이슈 페이지로 이동합니다.
- 이슈 등록 버튼이 처음부터 활성화 된 문제를 해결했습니다. 제목이 처음부터 에러 상태가 안 되게 하기 위한 조치가 만든 사이드 이펙트로 보여 해결했습니다.(onTitleFocus를 하위 컴포넌트인 NewIssueBody로 이동)

## Issues

- #214 

## Next Step

- 이슈, 댓글 **작성자에게만 수정/삭제 버튼 보이기**
- 이슈, 댓글 응답 **예외처리**
- 마크다운 적용
