### PR TITLE
[fe] main Page 리팩토링

### DIFF
--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -252,6 +252,28 @@ export const handlers = [
 
     return res(ctx.status(200), ctx.json(issues));
   }),
+  rest.post("/api/issues/status", (req, res, ctx) => {
+    const body = JSON.parse(req.body as string) as {
+      issues: number[];
+      status: "OPENED" | "CLOSED";
+    };
+
+    issues.data.issues.forEach((issue) => {
+      issue.status = body.status;
+    });
+
+    return res(
+      ctx.status(200),
+      ctx.json({
+        code: 200,
+        status: "OK",
+        message: "OK",
+        data: {
+          modifiedIssueId: body.issues,
+        },
+      }),
+    );
+  }),
   rest.post("/login/oauth/github", (_, res, ctx) => {
     const response = {
       code: 200,
@@ -649,6 +671,12 @@ const issues = {
         multipleSelect: false,
         options: [
           {
+            id: 0,
+            name: "담당자가 없는 이슈",
+            avatarUrl: null,
+            selected: false,
+          },
+          {
             id: 1,
             name: "yeon",
             avatarUrl: "url path",
@@ -660,6 +688,11 @@ const issues = {
       labels: {
         multipleSelect: true,
         options: [
+          {
+            id: 0,
+            name: "레이블이 없는 이슈",
+            selected: false,
+          },
           {
             id: 1,
             name: "bug",
@@ -686,6 +719,11 @@ const issues = {
       milestones: {
         multipleSelect: false,
         options: [
+          {
+            id: 0,
+            name: "마일스톤이 없는 이슈",
+            selected: false,
+          },
           {
             id: 1,
             name: "week 1",

--- a/frontend/src/page/main/Main.tsx
+++ b/frontend/src/page/main/Main.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { styled } from "styled-components";
+import { getAccessToken } from "../../utils/localStorage";
 import { MainHeader } from "./MainHeader";
 import { MainTable } from "./MainTable";
 
@@ -92,7 +93,12 @@ export function Main() {
 
   useEffect(() => {
     const fetchData = async () => {
-      const res = await fetch(`/api/issues${queryString}`);
+      const res = await fetch(`/api/issues${queryString}`, {
+        credentials: "include",
+        headers: {
+          Authorization: `Bearer ${getAccessToken()}`,
+        },
+      });
       const { code, data } = await res.json();
 
       if (code === 200) {

--- a/frontend/src/page/main/MainTable.tsx
+++ b/frontend/src/page/main/MainTable.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { styled } from "styled-components";
 import { Icon } from "../../components/icon/Icon";
+import { getAccessToken } from "../../utils/localStorage";
 import { IssueDataState } from "./Main";
 import { MainTableElement } from "./MainTableElement";
 import { MainTableHeader } from "./MainTableHeader";
@@ -18,8 +19,20 @@ export function MainTable({
 }: MainTableProps) {
   const [checkedIssueId, setCheckedIssueId] = useState<number[]>([]);
 
-  const onChangeIssuesState = (state: "OPENED" | "CLOSED") => {
-    console.log(`${checkedIssueId} : ${state}`);
+  const onChangeIssuesState = async (state: "OPENED" | "CLOSED") => {
+    const body = {
+      issues: checkedIssueId,
+      status: state,
+    };
+
+    await fetch("/api/issues/status", {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Authorization: `Bearer ${getAccessToken()}`,
+      },
+      body: JSON.stringify(body),
+    });
   };
 
   const handleHeaderCheckbox = (checked: boolean) => {

--- a/frontend/src/page/main/MainTableHeader.tsx
+++ b/frontend/src/page/main/MainTableHeader.tsx
@@ -75,7 +75,10 @@ export function MainTableHeader({
     return options.map((option) => ({
       ...option,
       onClick: () => {
-        setMultiFilterString(`${key}:${option.name}`, multipleSelect);
+        setMultiFilterString(
+          `${key}:${option.id === 0 ? "none" : option.name}`,
+          multipleSelect,
+        );
       },
     }));
   };
@@ -90,7 +93,10 @@ export function MainTableHeader({
         <input
           type="checkbox"
           onChange={handleCheckboxChange}
-          checked={checkedIssueId.length === totalIssueCount}
+          checked={
+            checkedIssueId.length !== 0 &&
+            checkedIssueId.length === totalIssueCount
+          }
         />
       </CheckboxLabel>
       {!checkedIssueId.length ? (


### PR DESCRIPTION
## Description
- 멀티 필터 해당 드롭다운 필터링 제외하는 옵션 추가
- 이슈가 없는 경우 테이블 헤더에 있는 체크박스 체크되는 오류 수정
- 여러개의 이슈 상태 변경 api 추가
- api 호출에 accessToken 추가하기

## To Reviewers
- 우선 main page 리팩토링이 필요해 해당 관련 컴포넌트만 accessToken을 추가 했습니다.
- 백엔드 분들과 슬랙으로 짧게 이야기 하며 main page 관련 배포서버 api를 연결해 잠깐 테스트 해봤습니다.
  - 그래도 dev에 올려서 다 같이 테스트 할 필요는 있을 것 같습니다.
- 젤로의 다음 작업이 끝나면 dev-fe를 한번 dev로 올려주세요

## Next Step
- accessToken의 만료 시간이 5분이다.
- 그 5분이 지난 시점에 서버로 api 요청을 보내면 403 code가 오며 그 때 accessToken과 refreshToken을 이용해 refresh api를 호출해 새 Token들을 발급 받고 오류가 났던 api를 다시 호출하는 로직이 구현
다음 진행 사항

## Issue
- #228 