### PR TITLE
[fe] 페이지 재렌더링마다 마일스톤 api 호출되는 문제 해결

### DIFF
--- a/frontend/src/components/sidebar/AddMilestone.tsx
+++ b/frontend/src/components/sidebar/AddMilestone.tsx
@@ -44,6 +44,16 @@ export function AddMilestone({
   onMilestoneClick,
 }: AddMilestoneProps) {
   const [milestones, setMilestones] = useState<MilestoneData[]>([]);
+  const [milestonesRes, setMilestonesRes] = useState<
+    {
+      id: number;
+      name: string;
+      issues: {
+        openedIssueCount: number;
+        closedIssueCount: number;
+      };
+    }[]
+  >([]);
 
   const handleMilestoneClick = useCallback(
     (clickedMilestone: {
@@ -80,7 +90,15 @@ export function AddMilestone({
     });
     const result = await response.json();
 
-    const milestonesData = result.data.milestones.map(
+    setMilestonesRes(result.data.milestones);
+  }, []);
+
+  useEffect(() => {
+    fetchMilestones();
+  }, [fetchMilestones]);
+
+  useEffect(() => {
+    const milestonesData = milestonesRes.map(
       (milestone: {
         id: number;
         name: string;
@@ -100,11 +118,7 @@ export function AddMilestone({
     );
 
     setMilestones(milestonesData);
-  }, [handleMilestoneClick]);
-
-  useEffect(() => {
-    fetchMilestones();
-  }, [fetchMilestones]);
+  }, [milestonesRes, handleMilestoneClick]);
 
   useEffect(() => {
     setMilestones((milestones) =>


### PR DESCRIPTION
## Description

이슈 작성, 상세 페이지에서 페이지 재렌더링마다 마일스톤 목록 API 요청이 발생하는 문제

- 마일스톤 요청과 상태 초기화 로직을 분리해서 해결했습니다.

## Next Step

- 이슈, 댓글 응답 예외처리
- 반응 버튼