### PR TITLE
[fe] 배포 서버에서 테스트 후 피드백 반영

### DIFF
--- a/frontend/src/components/MarkdownViewer.tsx
+++ b/frontend/src/components/MarkdownViewer.tsx
@@ -82,6 +82,11 @@ const Div = styled.div`
   ol {
     list-style: disc;
     padding-left: 2em;
+
+  }
+  
+  .contains-task-list {
+    list-style: none;
   }
 
   div,

--- a/frontend/src/components/TextArea.tsx
+++ b/frontend/src/components/TextArea.tsx
@@ -167,23 +167,22 @@ export function TextArea({
     const formData = new FormData();
     formData.append("image", file as File);
 
-    try {
-      const response = await fetch("/api/images", {
-        method: "POST",
-        credentials: "include",
-        headers: {
-          "Content-Type": "multipart/form-data",
-          Authorization: `Bearer ${getAccessToken()}`,
-        },
-        body: formData,
-      });
-      const data = await response.json();
+    const response = await fetch("/api/images", {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        Authorization: `Bearer ${getAccessToken()}`,
+      },
+      body: formData,
+    });
+    const { code, message, data} = await response.json();
 
-      return data.data.url;
-    } catch (error) {
-      setUploadErrorMessage("이미지 업로드에 실패했습니다.");
-      throw new Error("이미지 업로드에 실패했습니다.");
-    }
+    if (code === 201) {
+      return data.url;
+    } 
+
+    setUploadErrorMessage(message);
+    throw new Error(message);
   };
 
   return (

--- a/frontend/src/components/TextArea.tsx
+++ b/frontend/src/components/TextArea.tsx
@@ -165,7 +165,7 @@ export function TextArea({
       return data.url;
     }
 
-    alert(message);
+    alert(`[이미지 저장 실패!]\n${message}`);
     throw new Error(message);
   };
 

--- a/frontend/src/components/TextArea.tsx
+++ b/frontend/src/components/TextArea.tsx
@@ -11,6 +11,7 @@ import { getAccessToken } from "../utils/localStorage";
 import { Button } from "./Button";
 import { MarkdownViewer } from "./MarkdownViewer";
 import { Icon } from "./icon/Icon";
+import { text } from "stream/consumers";
 
 type TextAreaProps = {
   value?: string;
@@ -45,8 +46,8 @@ export function TextArea({
   const [countHidden, setCountHidden] = useState(true);
   const [uploadErrorMessage, setUploadErrorMessage] = useState("");
   const componentRef = useRef<HTMLDivElement>(null);
-  const textArea = useRef<HTMLTextAreaElement>(null);
-  const fileInput = useRef<HTMLInputElement>(null);
+  const textAreaRef = useRef<HTMLTextAreaElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     setInputValue(value);
@@ -54,11 +55,19 @@ export function TextArea({
 
   useEffect(() => {
     if (isEditing) {
-      textArea.current?.focus();
+      setState("Active");
     } else {
       setState("Enabled");
     }
   }, [isEditing]);
+
+  useEffect(() => {
+    if (state === "Active" && textAreaRef.current) {
+      textAreaRef.current.selectionStart = textAreaRef.current.value.length;
+      textAreaRef.current.selectionStart = textAreaRef.current.value.length;
+      textAreaRef.current.focus();
+    }
+  }, [state]);
 
   useEffect(() => {
     let timer: ReturnType<typeof setTimeout>;
@@ -103,7 +112,7 @@ export function TextArea({
   };
 
   const onFileInputClick = () => {
-    fileInput.current?.click();
+    fileInputRef.current?.click();
   };
 
   const onFileInputChange = async (e: ChangeEvent<HTMLInputElement>) => {
@@ -113,8 +122,8 @@ export function TextArea({
       const data = await fetchImageText(file);
 
       const dataIntoTextArea = (i: string) => {
-        const start = textArea.current?.selectionStart;
-        const end = textArea.current?.selectionEnd;
+        const start = textAreaRef.current?.selectionStart;
+        const end = textAreaRef.current?.selectionEnd;
 
         if (start === undefined || end === undefined) {
           return i;
@@ -201,7 +210,7 @@ export function TextArea({
                   maxLength={maxLength}
                   onChange={onTextChange}
                   disabled={disabled}
-                  ref={textArea}
+                  ref={textAreaRef}
                 />
                 <TextCount $hidden={countHidden}>
                   띄어쓰기 포함 {inputValue.length}글자
@@ -222,7 +231,7 @@ export function TextArea({
                 type="file"
                 accept="image/*"
                 onChange={onFileInputChange}
-                ref={fileInput}
+                ref={fileInputRef}
                 hidden
               />
             </Footer>

--- a/frontend/src/components/comment/CommentEditor.tsx
+++ b/frontend/src/components/comment/CommentEditor.tsx
@@ -12,32 +12,24 @@ type CommentEditorProps = {
 
 export function CommentEditor({ issueId, fetchIssue }: CommentEditorProps) {
   const [content, setContent] = useState("");
-  const [invalidContent, setInvalidContent] = useState(false);
-  const [errorDescription, setErrorDescription] = useState("");
+  const [isFocused, setIsFocused] = useState(false);
 
   const maxContentLength = 10000;
-
-  const validateContent = (value: string) => {
-    const emptyContent = value.length === 0;
-    const overflowContent = value.length > maxContentLength;
-
-    setInvalidContent(emptyContent || overflowContent);
-    setErrorDescription(
-      emptyContent
-        ? "내용을 입력해주세요"
-        : overflowContent
-        ? `내용은 ${addCommasToNumber(maxContentLength)}자 이내로 입력해주세요`
-        : "",
-    );
-  };
+  const emptyContent = content.length === 0;
+  const overflowContent = content.length > maxContentLength;
+  const invalidContent = emptyContent || overflowContent;
+  const errorDescription = emptyContent
+    ? "내용을 입력해주세요"
+    : overflowContent
+    ? `내용은 ${addCommasToNumber(maxContentLength)}자 이내로 입력해주세요`
+    : "";
 
   const onEditorFocus = () => {
-    validateContent(content);
+    setIsFocused(true);
   };
 
   const onContentChange = (value: string) => {
     setContent(value);
-    validateContent(value);
   };
 
   const onContentSubmit = async () => {
@@ -56,8 +48,6 @@ export function CommentEditor({ issueId, fetchIssue }: CommentEditorProps) {
     });
 
     setContent("");
-    setInvalidContent(false);
-    setErrorDescription("");
     fetchIssue();
   };
 
@@ -69,12 +59,11 @@ export function CommentEditor({ issueId, fetchIssue }: CommentEditorProps) {
         height={200}
         placeholder="코멘트를 입력하세요"
         label="코멘트를 입력하세요"
+        isEditing={isFocused}
+        errorDescription={errorDescription}
         onChange={onContentChange}
         onTextAreaFocus={onEditorFocus}
       />
-      {errorDescription && (
-        <ErrorDescription>{errorDescription}</ErrorDescription>
-      )}
       <Button
         size="S"
         buttonType="Container"
@@ -94,14 +83,4 @@ const Div = styled.div`
   flex-direction: column;
   align-items: flex-end;
   gap: 24px;
-`;
-
-const ErrorDescription = styled.span`
-  display: flex;
-  padding-left: 0px;
-  align-items: flex-start;
-  align-self: stretch;
-  padding-left: 16px;
-  color: ${({ theme }) => theme.color.dangerTextDefault};
-  font: ${({ theme }) => theme.font.displayMedium12};
 `;

--- a/frontend/src/components/comment/CommentEditor.tsx
+++ b/frontend/src/components/comment/CommentEditor.tsx
@@ -4,6 +4,7 @@ import { addCommasToNumber } from "../../utils/addCommasToNumber";
 import { getAccessToken } from "../../utils/localStorage";
 import { Button } from "../Button";
 import { TextArea } from "../TextArea";
+import { useNavigate } from "react-router";
 
 type CommentEditorProps = {
   issueId: number;
@@ -11,6 +12,8 @@ type CommentEditorProps = {
 };
 
 export function CommentEditor({ issueId, fetchIssue }: CommentEditorProps) {
+  const navigate = useNavigate();
+
   const [content, setContent] = useState("");
   const [isFocused, setIsFocused] = useState(false);
 
@@ -34,10 +37,11 @@ export function CommentEditor({ issueId, fetchIssue }: CommentEditorProps) {
 
   const onContentSubmit = async () => {
     if (invalidContent) {
+      alert(`코멘트 ${errorDescription}`);
       return;
     }
 
-    await fetch("/api/comments", {
+    const response = await fetch("/api/comments", {
       method: "POST",
       credentials: "include",
       headers: {
@@ -46,9 +50,23 @@ export function CommentEditor({ issueId, fetchIssue }: CommentEditorProps) {
       },
       body: JSON.stringify({ issueId, content }),
     });
+    const {code, message, data} = await response.json();
 
-    setContent("");
-    fetchIssue();
+    if (code === 201) {
+      setContent("");
+      fetchIssue();
+      return;
+    }
+
+    if (code === 404) {
+      navigate("/404", { replace: true });
+      return;
+    }
+
+    const errorMessage = data ? data[0].defaultMessage : message;
+    
+    alert(errorMessage);
+    throw new Error(errorMessage);
   };
 
   return (

--- a/frontend/src/components/comment/CommentEditor.tsx
+++ b/frontend/src/components/comment/CommentEditor.tsx
@@ -37,7 +37,6 @@ export function CommentEditor({ issueId, fetchIssue }: CommentEditorProps) {
 
   const onContentSubmit = async () => {
     if (invalidContent) {
-      alert(`코멘트 ${errorDescription}`);
       return;
     }
 
@@ -65,7 +64,6 @@ export function CommentEditor({ issueId, fetchIssue }: CommentEditorProps) {
 
     const errorMessage = data ? data[0].defaultMessage : message;
     
-    alert(errorMessage);
     throw new Error(errorMessage);
   };
 

--- a/frontend/src/components/comment/CommentItem.tsx
+++ b/frontend/src/components/comment/CommentItem.tsx
@@ -74,7 +74,6 @@ export function CommentItem({
       return;
     }
 
-    alert(message);
     throw new Error(message);
   };
 
@@ -93,7 +92,6 @@ export function CommentItem({
 
   const onEditConfirmClick = async () => {
     if (invalidContent) {
-      alert(`코멘트의 ${errorDescription}`);
       return;
     }
 
@@ -119,7 +117,6 @@ export function CommentItem({
 
     const errorMessage = data ? data[0].defaultMessage : message;
     
-    alert(errorMessage);
     throw new Error(errorMessage);
   };
 

--- a/frontend/src/components/comment/CommentItem.tsx
+++ b/frontend/src/components/comment/CommentItem.tsx
@@ -37,8 +37,6 @@ export function CommentItem({
 
   const [isEditing, setIsEditing] = useState(false);
   const [content, setContent] = useState(initialContent);
-  const [invalidContent, setInvalidContent] = useState(false);
-  const [errorDescription, setErrorDescription] = useState("");
 
   useEffect(() => {
     setContent(initialContent);
@@ -47,23 +45,18 @@ export function CommentItem({
   const maxContentLength = 10000;
   const writtenAt = modifiedAt ?? createdAt;
   const loginUserInfo = getUserInfo();
-
-  const validateContent = (value: string) => {
-    const emptyContent = value.length === 0;
-    const sameContent = value === initialContent;
-    const overflowContent = value.length > maxContentLength;
-
-    setInvalidContent(emptyContent || sameContent || overflowContent);
-    setErrorDescription(
-      emptyContent
+  
+  const emptyContent = content.length === 0;
+  const sameContent = content === initialContent;
+  const overflowContent = content.length > maxContentLength;
+  const invalidContent = emptyContent || sameContent || overflowContent;
+  const errorDescription = emptyContent
         ? "내용을 입력해주세요"
         : sameContent
         ? "기존 내용과 동일합니다"
         : overflowContent
         ? `내용은 ${addCommasToNumber(maxContentLength)}자 이내로 입력해주세요`
-        : "",
-    );
-  };
+        : "";
 
   const deleteComment = async () => {
     await fetch(`/api/comments/${id}`, {
@@ -80,7 +73,6 @@ export function CommentItem({
 
   const onEditButtonClick = () => {
     setIsEditing(true);
-    validateContent(content);
   };
 
   const onEditCancelButtonClick = () => {
@@ -90,7 +82,6 @@ export function CommentItem({
 
   const onContentChange = (value: string) => {
     setContent(value);
-    validateContent(value);
   };
 
   const onEditConfirmClick = async () => {
@@ -108,8 +99,6 @@ export function CommentItem({
 
     setContent(initialContent);
     setIsEditing(false);
-    setInvalidContent(false);
-    setErrorDescription("");
     fetchIssue();
   };
 
@@ -119,6 +108,7 @@ export function CommentItem({
         value={content}
         width="100%"
         isEditing={isEditing}
+        errorDescription={errorDescription}
         onChange={onContentChange}
       >
         <WriterInfo>
@@ -174,9 +164,6 @@ export function CommentItem({
           </Button>
         </ControlButtons>
       </TextArea>
-      {isEditing && errorDescription && (
-        <ErrorDescription>{errorDescription}</ErrorDescription>
-      )}
       {isEditing && (
         <EditorButtons>
           <Button
@@ -223,16 +210,6 @@ const ControlButtons = styled.div`
     padding: 0;
     padding-left: 4px;
   }
-`;
-
-const ErrorDescription = styled.span`
-  display: flex;
-  padding-left: 0px;
-  align-items: flex-start;
-  align-self: stretch;
-  padding-left: 16px;
-  color: ${({ theme }) => theme.color.dangerTextDefault};
-  font: ${({ theme }) => theme.font.displayMedium12};
 `;
 
 const EditorButtons = styled.div`

--- a/frontend/src/components/comment/CommentItem.tsx
+++ b/frontend/src/components/comment/CommentItem.tsx
@@ -59,7 +59,7 @@ export function CommentItem({
         : "";
 
   const deleteComment = async () => {
-    await fetch(`/api/comments/${id}`, {
+    const response = await fetch(`/api/comments/${id}`, {
       method: "DELETE",
       credentials: "include",
       headers: {
@@ -67,8 +67,15 @@ export function CommentItem({
         Authorization: `Bearer ${getAccessToken()}`,
       },
     });
+    const { code, message } = await response.json();
 
-    fetchIssue();
+    if (code === 200) {
+      fetchIssue();
+      return;
+    }
+
+    alert(message);
+    throw new Error(message);
   };
 
   const onEditButtonClick = () => {
@@ -85,7 +92,12 @@ export function CommentItem({
   };
 
   const onEditConfirmClick = async () => {
-    await fetch(`/api/comments/${id}`, {
+    if (invalidContent) {
+      alert(`코멘트의 ${errorDescription}`);
+      return;
+    }
+
+    const response = await fetch(`/api/comments/${id}`, {
       method: "PATCH",
       credentials: "include",
       headers: {
@@ -96,10 +108,19 @@ export function CommentItem({
         content: content,
       }),
     });
+    const { code, message, data } = await response.json();
 
-    setContent(initialContent);
-    setIsEditing(false);
-    fetchIssue();
+    if (code === 200) {
+      setContent(initialContent);
+      setIsEditing(false);
+      fetchIssue();
+      return;
+    }
+
+    const errorMessage = data ? data[0].defaultMessage : message;
+    
+    alert(errorMessage);
+    throw new Error(errorMessage);
   };
 
   return (

--- a/frontend/src/components/comment/CommentList.tsx
+++ b/frontend/src/components/comment/CommentList.tsx
@@ -24,5 +24,5 @@ const Div = styled.div`
   align-self: stretch;
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 16px;
 `;

--- a/frontend/src/page/issueDetail/IssueContent.tsx
+++ b/frontend/src/page/issueDetail/IssueContent.tsx
@@ -22,8 +22,6 @@ export function IssueContent({
 }: IssueContentProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [content, setContent] = useState(initialContent);
-  const [invalidContent, setInvalidContent] = useState(false);
-  const [errorDescription, setErrorDescription] = useState("");
 
   useEffect(() => {
     setContent(initialContent);
@@ -33,23 +31,17 @@ export function IssueContent({
   const writtenAt = modifiedAt ?? createdAt;
   const loginUserInfo = getUserInfo();
 
-  const validateContent = (value: string) => {
-    const sameContent = value === initialContent;
-    const overflowContent = value.length > maxContentLength;
-
-    setInvalidContent(sameContent || overflowContent);
-    setErrorDescription(
-      sameContent
-        ? "기존 내용과 동일합니다"
-        : overflowContent
-        ? `내용은 ${addCommasToNumber(maxContentLength)}자 이내로 입력해주세요`
-        : "",
-    );
-  };
+  const sameContent = content === initialContent;
+  const overflowContent = content.length > maxContentLength;
+  const invalidContent = sameContent || overflowContent;
+  const errorDescription = sameContent
+  ? "기존 내용과 동일합니다"
+  : overflowContent
+  ? `내용은 ${addCommasToNumber(maxContentLength)}자 이내로 입력해주세요`
+  : "";
 
   const onEditButtonClick = () => {
     setIsEditing(true);
-    validateContent(content);
   };
 
   const onEditCancelButtonClick = () => {
@@ -59,7 +51,6 @@ export function IssueContent({
 
   const onContentChange = (value: string) => {
     setContent(value);
-    validateContent(value);
   };
 
   const onEditConfirmClick = async () => {
@@ -77,8 +68,6 @@ export function IssueContent({
 
     setContent(initialContent);
     setIsEditing(false);
-    setInvalidContent(false);
-    setErrorDescription("");
     fetchIssue();
   };
 
@@ -88,6 +77,7 @@ export function IssueContent({
         value={content}
         width="100%"
         isEditing={isEditing}
+        errorDescription={errorDescription}
         onChange={onContentChange}
       >
         <WriterInfo>
@@ -126,9 +116,6 @@ export function IssueContent({
           </Button>
         </ControlButtons>
       </TextArea>
-      {isEditing && errorDescription && (
-        <ErrorDescription>{errorDescription}</ErrorDescription>
-      )}
       {isEditing && (
         <EditorButtons>
           <Button
@@ -175,16 +162,6 @@ const ControlButtons = styled.div`
     padding: 0;
     padding-left: 4px;
   }
-`;
-
-const ErrorDescription = styled.span`
-  display: flex;
-  padding-left: 0px;
-  align-items: flex-start;
-  align-self: stretch;
-  padding-left: 16px;
-  color: ${({ theme }) => theme.color.dangerTextDefault};
-  font: ${({ theme }) => theme.font.displayMedium12};
 `;
 
 const EditorButtons = styled.div`

--- a/frontend/src/page/issueDetail/IssueDetail.tsx
+++ b/frontend/src/page/issueDetail/IssueDetail.tsx
@@ -109,7 +109,11 @@ export function IssueDetail() {
     }
     if (result.code === 404) {
       navigatte("/404", { replace: true });
+      return;
     }
+
+    alert(result.message);
+    throw new Error(result.message);
   }, [issueId, navigatte]);
 
   useEffect(() => {

--- a/frontend/src/page/issueDetail/IssueDetail.tsx
+++ b/frontend/src/page/issueDetail/IssueDetail.tsx
@@ -112,7 +112,6 @@ export function IssueDetail() {
       return;
     }
 
-    alert(result.message);
     throw new Error(result.message);
   }, [issueId, navigatte]);
 

--- a/frontend/src/page/issueDetail/IssueDetailMainContent.tsx
+++ b/frontend/src/page/issueDetail/IssueDetailMainContent.tsx
@@ -29,5 +29,5 @@ const Div = styled.div`
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 24px;
+  gap: 16px;
 `;

--- a/frontend/src/page/issueDetail/IssueDetailSidePanel.tsx
+++ b/frontend/src/page/issueDetail/IssueDetailSidePanel.tsx
@@ -23,7 +23,7 @@ export function IssueDetailSidePanel({
   const loginUserInfo = getUserInfo();
 
   const patchIssueAssignees = async (ids: number[]) => {
-    await fetch(`/api/issues/${issueId}/assignees`, {
+    const response = await fetch(`/api/issues/${issueId}/assignees`, {
       method: "PATCH",
       credentials: "include",
       headers: {
@@ -34,12 +34,19 @@ export function IssueDetailSidePanel({
         assignees: ids,
       }),
     });
+    const { code, message } = await response.json();
 
-    fetchIssue();
+    if (code === 200) {
+      fetchIssue();
+      return;
+    }
+
+    alert("작성자 이외에는 수정할 수 없습니다!");
+    throw new Error(message);
   };
 
   const patchIssueLabels = async (ids: number[]) => {
-    await fetch(`/api/issues/${issueId}/labels`, {
+    const response = await fetch(`/api/issues/${issueId}/labels`, {
       method: "PATCH",
       credentials: "include",
       headers: {
@@ -50,12 +57,19 @@ export function IssueDetailSidePanel({
         labels: ids,
       }),
     });
+    const { code, message } = await response.json();
 
-    fetchIssue();
+    if (code === 200) {
+      fetchIssue();
+      return;
+    }
+
+    alert("작성자 이외에는 수정할 수 없습니다!");
+    throw new Error(message);
   };
 
   const patchIssueMilestone = async (id: number | null) => {
-    await fetch(`/api/issues/${issueId}/milestones`, {
+    const response = await fetch(`/api/issues/${issueId}/milestones`, {
       method: "PATCH",
       credentials: "include",
       headers: {
@@ -66,12 +80,19 @@ export function IssueDetailSidePanel({
         milestone: id,
       }),
     });
+    const { code, message } = await response.json();
 
-    fetchIssue();
+    if (code === 200) {
+      fetchIssue();
+      return;
+    }
+
+    alert("작성자 이외에는 수정할 수 없습니다!");
+    throw new Error(message);
   };
 
   const deleteIssue = async () => {
-    await fetch(`/api/issues/${issueId}`, {
+    const response = await fetch(`/api/issues/${issueId}`, {
       method: "DELETE",
       credentials: "include",
       headers: {
@@ -79,8 +100,15 @@ export function IssueDetailSidePanel({
         Authorization: `Bearer ${getAccessToken()}`,
       },
     });
+    const { code, message } = await response.json();
 
-    navigate("/");
+    if (code === 200) {
+      navigate("/");
+      return;
+    }
+
+    alert(message);
+    throw new Error(message);
   };
 
   return (

--- a/frontend/src/page/issueDetail/IssueDetailSidePanel.tsx
+++ b/frontend/src/page/issueDetail/IssueDetailSidePanel.tsx
@@ -41,7 +41,6 @@ export function IssueDetailSidePanel({
       return;
     }
 
-    alert("작성자 이외에는 수정할 수 없습니다!");
     throw new Error(message);
   };
 
@@ -64,7 +63,6 @@ export function IssueDetailSidePanel({
       return;
     }
 
-    alert("작성자 이외에는 수정할 수 없습니다!");
     throw new Error(message);
   };
 
@@ -87,7 +85,6 @@ export function IssueDetailSidePanel({
       return;
     }
 
-    alert("작성자 이외에는 수정할 수 없습니다!");
     throw new Error(message);
   };
 
@@ -107,7 +104,6 @@ export function IssueDetailSidePanel({
       return;
     }
 
-    alert(message);
     throw new Error(message);
   };
 

--- a/frontend/src/page/issueDetail/IssueDetailTitleInfo.tsx
+++ b/frontend/src/page/issueDetail/IssueDetailTitleInfo.tsx
@@ -42,7 +42,7 @@ export function IssueDetailTitleInfo({
   };
 
   const onEditClick = async () => {
-    await fetch(`/api/issues/${id}/title`, {
+    const response = await fetch(`/api/issues/${id}/title`, {
       method: "PATCH",
       credentials: "include",
       headers: {
@@ -51,13 +51,20 @@ export function IssueDetailTitleInfo({
       },
       body: JSON.stringify({ title }),
     });
+    const { code, message } = await response.json();
 
-    setIsTitleEditing(false);
-    fetchIssue();
+    if (code === 200) {
+      setIsTitleEditing(false);
+      fetchIssue();
+      return;
+    }
+
+    alert(message);
+    throw new Error(message);
   };
 
   const onStatusChangeClick = async () => {
-    await fetch(`/api/issues/${id}/status`, {
+    const response = await fetch(`/api/issues/${id}/status`, {
       method: "PATCH",
       credentials: "include",
       headers: {
@@ -65,11 +72,24 @@ export function IssueDetailTitleInfo({
         Authorization: `Bearer ${getAccessToken()}`,
       },
       body: JSON.stringify({
+        issues: [id],
         status: status === "OPENED" ? "CLOSED" : "OPENED",
       }),
     });
+    const { code, message, data } = await response.json();
 
-    fetchIssue();
+    if (code === 200) {
+      fetchIssue();
+      return;      
+    }
+
+    if (code === 400) {
+      alert(data[0].defaultMessage)
+      throw new Error(data[0].defaultMessage);
+    }
+
+    alert(message);
+    throw new Error(message);
   };
 
   return (

--- a/frontend/src/page/issueDetail/IssueDetailTitleInfo.tsx
+++ b/frontend/src/page/issueDetail/IssueDetailTitleInfo.tsx
@@ -59,7 +59,6 @@ export function IssueDetailTitleInfo({
       return;
     }
 
-    alert(message);
     throw new Error(message);
   };
 
@@ -84,11 +83,9 @@ export function IssueDetailTitleInfo({
     }
 
     if (code === 400) {
-      alert(data[0].defaultMessage)
       throw new Error(data[0].defaultMessage);
     }
 
-    alert(message);
     throw new Error(message);
   };
 

--- a/frontend/src/page/newIssue/NewIssue.tsx
+++ b/frontend/src/page/newIssue/NewIssue.tsx
@@ -60,11 +60,15 @@ export function NewIssue() {
       },
       body: JSON.stringify(issueData),
     });
-    const result = await response.json();
+    const { code, data} = await response.json();
 
-    if (result.code === 201) {
-      navigate(`/issues/${result.data.savedIssueId}`);
+    if (code === 201) {
+      navigate(`/issues/${data.savedIssueId}`);
+      return;
     }
+
+    alert(data[0].defaultMessage);
+    throw new Error(data[0].defaultMessage);
   };
 
   const onCancelButtonClick = () => {

--- a/frontend/src/page/newIssue/NewIssue.tsx
+++ b/frontend/src/page/newIssue/NewIssue.tsx
@@ -17,7 +17,7 @@ export function NewIssue() {
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
 
-  const invalidTitle = title.length === 0;
+  const invalidTitle = title.length === 0 || title.length > 50;
 
   const onTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTitle(e.target.value);
@@ -43,6 +43,11 @@ export function NewIssue() {
   );
 
   const onSubmitButtonClick = async () => {
+    if (invalidTitle) {
+      alert("제목은 1글자 이상 50글자 이하로 작성해주세요.");
+      return;
+    }
+
     const issueData = {
       title: title,
       content: content,
@@ -60,7 +65,7 @@ export function NewIssue() {
       },
       body: JSON.stringify(issueData),
     });
-    const { code, data} = await response.json();
+    const { code, data } = await response.json();
 
     if (code === 201) {
       navigate(`/issues/${data.savedIssueId}`);

--- a/frontend/src/page/newIssue/NewIssue.tsx
+++ b/frontend/src/page/newIssue/NewIssue.tsx
@@ -44,7 +44,6 @@ export function NewIssue() {
 
   const onSubmitButtonClick = async () => {
     if (invalidTitle) {
-      alert("제목은 1글자 이상 50글자 이하로 작성해주세요.");
       return;
     }
 
@@ -72,7 +71,6 @@ export function NewIssue() {
       return;
     }
 
-    alert(data[0].defaultMessage);
     throw new Error(data[0].defaultMessage);
   };
 


### PR DESCRIPTION
## Description

- 이슈, 댓글 편집 모드로 전환되지 않는 문제 수정
- checkbox 앞에 점이 생기는 문제 
  - `.contain-task-list`의 list-style:none
- 이미지 저장 API 요청 500에러 지속적으로 발생하는 문제
  - `Content-Type: multipart/form-data` 임의 지정으로 인한 문제
  - 위 속성을 headers에서 제거해서 해결
- 이슈, 댓글 validation 설명의 위치를 TextArea 밖에서 안으로 변경함
- 이슈 CRUD, 댓글 CUD 예외처리
  - 404 외 alert로 메시지를 사용자에게 보여줌

## Next Step

다음 진행 사항

- 반응 구현